### PR TITLE
chore(core): replace startup print with logger in main

### DIFF
--- a/core/app/main.py
+++ b/core/app/main.py
@@ -132,7 +132,7 @@ async def serve():
 
     server_address = os.getenv("GRPC_SERVER_ADDRESS", "localhost:50053")
     host, port = server_address.split(":")
-    print(f"Starting gRPC server at {server_address}...")
+    _LOGGER.info("Starting gRPC server at %s...", server_address)
 
     await server.start(host, int(port))
     try:


### PR DESCRIPTION
Replaces the stray `print(...)` at the gRPC server startup in `core/app/main.py` with `_LOGGER.info(...)`, matching the existing logger usage in the same function (shutdown/interrupt paths). Follow-up cleanup after #12.