### PR TITLE
fix(conversation): avoid creating a conversation on chat reconnect

### DIFF
--- a/backend/internal/biz/conversation/impl/chat.go
+++ b/backend/internal/biz/conversation/impl/chat.go
@@ -526,9 +526,27 @@ func (s *Service) Reconnect(ctx context.Context, sender sse.SSESender, req *conv
 	// ensure agent ID is set for downstream usage, in case only agentInstanceId is provided.
 	agentID := singleAgent.GetAgentId()
 
-	conversation, err := s.ensureConversation(ctx, agentID, req.AgentInstanceID, username)
+	// Reconnect resumes an in-progress turn, so the conversation must already
+	// exist. Look it up read-only rather than get-or-create: a missing
+	// conversation cannot have an ongoing turn to resume, and creating one here
+	// would leave a stray empty conversation as a side effect of a reconnect.
+	conversation, err := s.conversationRepo.Get(ctx, username, agentID, req.AgentInstanceID)
 	if err != nil {
+		logger.CtxError(ctx, "chat_reconnect_conversation_lookup_failed username=%s agentId=%s agentInstanceId=%d err=%v",
+			username, agentID, req.AgentInstanceID, err)
 		return err
+	}
+
+	// No conversation means there is nothing to resume; end the stream without
+	// creating a conversation or touching the ongoing-turn cache.
+	if conversation == nil {
+		logger.CtxInfo(ctx, "chat_reconnect_no_conversation agentInstanceId=%d username=%s",
+			req.AgentInstanceID, username)
+		if sendErr := sender.Send(ctx, buildDoneEvent()); sendErr != nil {
+			logger.CtxWarn(ctx, "chat_reconnect_done_send_failed err=%v", sendErr)
+		}
+		sender.NotifyClosed()
+		return nil
 	}
 
 	sendDoneResponse := func() {

--- a/backend/internal/biz/conversation/impl/chat_test.go
+++ b/backend/internal/biz/conversation/impl/chat_test.go
@@ -196,3 +196,36 @@ func hasWaitForReadyOption(opts []grpc.CallOption) bool {
 	}
 	return false
 }
+
+func TestReconnect(t *testing.T) {
+	service := newTestConversationService()
+	service.agentSvc = &mockAgentService{}
+	// chatClient only needs to be non-nil to pass the guard; the no-conversation
+	// path never issues a StreamChat call.
+	service.chatClient = &mockChatClient{}
+
+	t.Run("no conversation does not create one and sends done", func(t *testing.T) {
+		ctx := ctxWithUser("alice")
+		sseSender := sse.NewMockSSESender()
+		req := &conversationdto.ReconnectRequest{AgentInstanceID: 1}
+
+		err := service.Reconnect(ctx, sseSender, req)
+		require.NoError(t, err)
+
+		// Reconnecting to a non-existent conversation must not create one as a
+		// side effect; it should stay absent.
+		conv, err := service.conversationRepo.Get(ctx, "alice", "agent-123", 1)
+		require.NoError(t, err)
+		require.Nil(t, conv)
+
+		// Only a terminal done event is emitted; there is nothing to resume.
+		sentEvents := make([]*sse.Event, 0)
+		for _, event := range sseSender.Sent {
+			if event.Event != "keepalive" {
+				sentEvents = append(sentEvents, event)
+			}
+		}
+		require.Len(t, sentEvents, 1)
+		require.Equal(t, "done", sentEvents[0].Event)
+	})
+}


### PR DESCRIPTION
## Summary

`Reconnect` previously called `ensureConversation` (get-or-create). A reconnect
only resumes an in-progress turn, so when a client reconnects to an agent
instance that has no existing conversation, creating one is unnecessary and a
side effect — it leaves a stray empty conversation and then immediately ends the
stream because there is no ongoing turn.

This changes `Reconnect` to look the conversation up read-only
(`conversationRepo.Get`). If none exists, it sends the terminal `done` event and
returns without creating a conversation or touching the ongoing-turn cache.
`Chat` still uses `ensureConversation`, where first-turn creation is expected.

## Validation

- [x] `make precommit-run`
- [x] `cd backend && go test ./...`
- [ ] `cd core && uv run pytest`
- [ ] Frontend build/lint, if working from a frontend source checkout
- [x] Not run; explain below

Backend-only change. `make precommit-run`, `go test ./...`, and
`golangci-lint run` all pass locally. Core and frontend suites were not run
because neither is touched by this change.

## Checklist

- [ ] Linked relevant issues or explained why there is no issue.
- [x] Updated docs and examples where behavior changed.
- [ ] Updated `CHANGELOG.md` under `## [Unreleased]` for user-facing changes.
- [x] Regenerated and committed generated files after proto, Wire, or OpenAPI changes.
- [x] Confirmed no secrets, tokens, credentials, or sensitive logs are included.

<!--
- No linked issue: code-review follow-up item, not tracked by an issue.
- Docs/examples: N/A — no user-facing docs describe this internal behavior.
- CHANGELOG: intentionally omitted; removes an internal stray-record side effect,
  judged below the user-facing bar. Can add a `Fixed` entry if preferred.
- Generated files: N/A.
-->

## Notes for reviewers

- New test `TestReconnect` covers the "no conversation -> don't create, send
  done" path. The cache-backed resume paths still require Redis and aren't
  unit-tested here (`s.cache` is a concrete `*redis.Client`); covering them would
  need miniredis or a cache interface — possible follow-up.
- Files changed: `chat.go` (fix) and `chat_test.go` (test).
- Branch is rebased onto latest `main`.