### PR TITLE
fix(llmhubs): add credential placeholders to model config templates

### DIFF
--- a/deploy/config/llmhubs/gpt5.4-template.yaml
+++ b/deploy/config/llmhubs/gpt5.4-template.yaml
@@ -30,6 +30,9 @@ provider_template_type: azure_openai
 config:
   deployment_name: gpt-5.4
   endpoint: https://YOUR-RESOURCE.cognitiveservices.azure.com/
+  # Auth: set AZURE_OPENAI_API_KEY for key-based auth. Leave the env var unset
+  # to fall back to Azure managed identity (DefaultAzureCredential).
+  api_key: ${AZURE_OPENAI_API_KEY:-}
   api_version: preview
   timeout_ms: 60000
   max_tokens: 128000

--- a/deploy/config/llmhubs/model-template.yaml
+++ b/deploy/config/llmhubs/model-template.yaml
@@ -40,6 +40,7 @@ io_profile:
 #   config:
 #     endpoint: https://example.cognitiveservices.azure.com/
 #     deployment_name: gpt-5.4
+#     api_key: ${AZURE_OPENAI_API_KEY:-}  # key auth; leave env unset for managed identity
 #     api_version: preview              # v1 API — no api-version in URL
 #     unsupported_request_options: []   # Optional: drop request options the model rejects
 #     timeout_ms: 60000
@@ -51,6 +52,7 @@ io_profile:
 #   config:
 #     endpoint: https://example.services.ai.azure.com/openai/v1
 #     deployment_name: DeepSeek-V3.2
+#     api_key: ${AZURE_OPENAI_API_KEY:-}  # key auth; leave env unset for managed identity
 #     api_version: preview
 #     use_chat_completions: true         # stay on Chat Completions
 #     unsupported_request_options: []    # Optional: drop request options the model rejects
@@ -63,6 +65,7 @@ io_profile:
 #     base_url: https://api.deepseek.com
 #     path: /chat/completions
 #     upstream_model_name: deepseek-reasoner
+#     bearer_token: ${DEEPSEEK_API_KEY}   # sent as Authorization: Bearer <token>
 #     use_chat_completions: true        # Optional: force Chat Completions for this model
 #     use_responses_api: true           # Optional: force Responses API when request shape is supported
 #     passthrough_options: []            # Optional: allow specific request.options keys for all request types
@@ -81,6 +84,7 @@ io_profile:
 #   config:
 #     base_url: https://openrouter.ai/api/v1
 #     upstream_model_name: anthropic/claude-sonnet-4
+#     bearer_token: ${OPENROUTER_API_KEY}  # sent as Authorization: Bearer <token>
 #     use_responses_api: true           # Optional: enable /responses for OpenRouter
 #     site_url: https://example.com  # Optional: sent as HTTP-Referer unless default_headers already sets it
 #     app_name: Sico                      # Optional: sent as X-OpenRouter-Title unless default_headers already sets it
@@ -91,6 +95,7 @@ io_profile:
 #   config:
 #     base_url: https://api.anthropic.com
 #     upstream_model_name: claude-sonnet-4-20250514
+#     api_key_value: ${ANTHROPIC_API_KEY}  # sent as x-api-key header
 #     timeout_ms: 60000
 #     max_tokens: 4096
 #
@@ -98,6 +103,7 @@ io_profile:
 #   config:
 #     base_url: https://generativelanguage.googleapis.com
 #     upstream_model_name: gemini-2.5-flash
+#     api_key_value: ${GEMINI_API_KEY}   # API key for Gemini
 #     timeout_ms: 60000
 #     max_tokens: 4096
 #
@@ -132,6 +138,9 @@ io_profile:
 config:
   deployment_name: your-deployment-name
   endpoint: https://example.openai.azure.com/
+  # Auth: set AZURE_OPENAI_API_KEY for key-based auth. Leave the env var unset
+  # to fall back to Azure managed identity (DefaultAzureCredential).
+  api_key: ${AZURE_OPENAI_API_KEY:-}
   api_version: preview
   timeout_ms: 60000
   max_tokens: 4096


### PR DESCRIPTION
## Summary

The llmhubs config templates under `deploy/config/llmhubs/` were missing the
credential/auth field, so a user copying a template to activate a model had no
indication of how to supply an API key — inconsistent with the existing
OpenRouter template, which already included one.

This adds the correct, provider-specific credential placeholder (as an
environment-variable reference) to each provider example:

- Azure OpenAI / Azure AI Foundry → `api_key: ${AZURE_OPENAI_API_KEY:-}`
- OpenAI-compatible / OpenRouter → `bearer_token: ${<PROVIDER>_API_KEY}`
- Anthropic / Gemini → `api_key_value: ${<PROVIDER>_API_KEY}` (sent as `x-api-key`)
- The active `gpt5.4-template.yaml` config and the active config in
  `model-template.yaml` also get `api_key: ${AZURE_OPENAI_API_KEY:-}` plus a
  short auth comment.

All values are env-var references — no secrets are committed. Field names match
what each adapter reads (`adapters/base.py._build_auth_headers`; the Azure
adapter/embedding readers use `config["api_key"]`). The `${VAR:-}` vs `${VAR}`
choice is deliberate and matches `config_loader` semantics: an empty default
keeps the descriptor loadable (Azure falls back to managed identity when the key
is unset), while a bare `${VAR}` correctly skips a provider's model when its
required key is unset.

## Validation

- [x] `make precommit-run`
- [ ] `cd backend && go test ./...`
- [ ] `cd core && uv run pytest`
- [ ] Frontend build/lint, if working from a frontend source checkout
- [x] Not run; explain below

Backend/Core/Frontend suites are not applicable — this change only touches
`template: true` YAML data under `deploy/config/llmhubs/`; no Go, Python, or
frontend code changed. In addition to pre-commit, I verified the two files parse
as YAML and cross-checked every field name and the `${VAR:-}` / `${VAR}`
behavior against `core/app/llmhubs/config_loader.py` and
`core/app/llmhubs/adapters/base.py`.

## Checklist

- [x] Linked relevant issues or explained why there is no issue. *(No tracked
  issue; addresses a code-review comment that the llmhubs templates were
  incomplete/missing the key field.)*
- [x] Updated docs and examples where behavior changed. *(The templates are the
  docs; the existing `deploy/config/llmhubs/README.md` already documents
  `${VAR}` / `${VAR:-default}` substitution.)*
- [ ] Updated `CHANGELOG.md` under `## [Unreleased]` for user-facing changes.
  *(N/A — config-template/docs completeness only; no user-facing runtime change.)*
- [x] Regenerated and committed generated files after proto, Wire, or OpenAPI
  changes. *(N/A — none touched.)*
- [x] Confirmed no secrets, tokens, credentials, or sensitive logs are included.
  *(Only env-var placeholders; verified `git diff`.)*

## Notes for reviewers

- Both files carry `template: true`, so the loader skips them at runtime — this
  is documentation/example completeness only, **zero runtime behavior change**.
- Deliberate `${VAR:-}` (Azure) vs `${VAR}` (others): Azure supports a
  managed-identity fallback, so an empty key should still load the model; the
  other providers require a key, so the model should be skipped when unset. This
  matches `config_loader._expand_env_in_string` (empty explicit default is *not*
  treated as "missing").