### PR TITLE
feat(llmhubs): support tool calling and structured output in the Gemi…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,11 @@ Guidelines for editors:
 
 ### Added
 
+- Gemini adapter now supports function/tool calling and JSON-schema structured
+  output, including schema sanitization for Gemini's OpenAPI-subset (inlining
+  `$ref`/`$defs`, dropping `additionalProperties`, and mapping Optional
+  `anyOf` to `nullable`).
+
 ### Changed
 
 ### Deprecated

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,11 +24,6 @@ Guidelines for editors:
 
 ### Added
 
-- Gemini adapter now supports function/tool calling and JSON-schema structured
-  output, including schema sanitization for Gemini's OpenAPI-subset (inlining
-  `$ref`/`$defs`, dropping `additionalProperties`, and mapping Optional
-  `anyOf` to `nullable`).
-
 ### Changed
 
 ### Deprecated

--- a/backend/internal/biz/llmhubs/impl/model_registry.go
+++ b/backend/internal/biz/llmhubs/impl/model_registry.go
@@ -31,8 +31,8 @@ import (
 	"google.golang.org/protobuf/types/known/structpb"
 	"gorm.io/gorm"
 
-	"sico-backend/internal/shared/apperr"
 	"sico-backend/internal/errcode"
+	"sico-backend/internal/shared/apperr"
 	agentrepo "sico-backend/internal/store/agent/singleagent/repository"
 	registryrepo "sico-backend/internal/store/llmhubs/repository"
 	dto "sico-backend/internal/transport/http/dto/llmhubs"
@@ -333,9 +333,10 @@ func normalizeStructValue(value any) any {
 	}
 }
 
-func providerSupportsTools(t int32) bool              { return t == 1 || t == 2 }
+// Gemini (7) supports function calling and structured output via the Core GeminiAdapter.
+func providerSupportsTools(t int32) bool              { return t == 1 || t == 2 || t == 7 }
 func providerSupportsPreviousResponseID(t int32) bool { return t == 1 || t == 2 }
-func providerSupportsStructuredOutput(t int32) bool   { return t == 1 || t == 2 }
+func providerSupportsStructuredOutput(t int32) bool   { return t == 1 || t == 2 || t == 7 }
 
 // validateConfig checks that required config fields are present for each provider type.
 func validateConfig(m *registryrepo.ModelRegistryModel) error {

--- a/core/app/llmhubs/adapters/gemini.py
+++ b/core/app/llmhubs/adapters/gemini.py
@@ -25,11 +25,13 @@ Supports the Gemini generateContent REST API.
 
 from __future__ import annotations
 
+import json
 import logging
 from typing import Any
 
 from app.llmhubs.adapters.base import BaseAdapter, detect_media_type
 from app.llmhubs.types import (
+    InputContent,
     ModelRegistryEntry,
     OutputItem,
     Request,
@@ -41,26 +43,269 @@ logger = logging.getLogger(__name__)
 
 _DEFAULT_BASE_URL = "https://generativelanguage.googleapis.com"
 
+# OpenAI-style ``tool_choice`` string → Gemini functionCallingConfig.mode.
+_TOOL_CHOICE_MODE_MAP = {"auto": "AUTO", "none": "NONE", "required": "ANY"}
+
+# JSON-Schema keywords Gemini's OpenAPI-subset schema rejects outright.
+_GEMINI_UNSUPPORTED_SCHEMA_KEYS = frozenset({"$schema", "$defs", "$ref", "additionalProperties"})
+
+
+def _resolve_ref(ref: str, defs: dict[str, Any]) -> dict[str, Any] | None:
+    """Resolve a ``#/$defs/Name`` reference against the collected definitions."""
+    prefix = "#/$defs/"
+    if ref.startswith(prefix):
+        target = defs.get(ref[len(prefix):])
+        if isinstance(target, dict):
+            return target
+    return None
+
+
+def _normalize_optional(schema: dict[str, Any]) -> dict[str, Any] | None:
+    """Rewrite a Pydantic ``Optional`` (``anyOf`` with a null branch) via ``nullable``.
+
+    Returns the rewritten schema, or ``None`` if *schema* is not this pattern.
+    """
+    any_of = schema.get("anyOf")
+    if not isinstance(any_of, list):
+        return None
+    non_null = [s for s in any_of if not (isinstance(s, dict) and s.get("type") == "null")]
+    if len(non_null) == len(any_of):
+        return None
+    rest = {k: v for k, v in schema.items() if k != "anyOf"}
+    if len(non_null) == 1 and isinstance(non_null[0], dict):
+        return {**non_null[0], **rest, "nullable": True}
+    if non_null:
+        return {**rest, "anyOf": non_null, "nullable": True}
+    return {**rest, "nullable": True}
+
+
+def _sanitize_schema(
+    schema: Any,
+    defs: dict[str, Any] | None = None,
+    seen: frozenset[str] = frozenset(),
+) -> Any:
+    """Rewrite a JSON Schema into Gemini's supported subset.
+
+    Pydantic-generated tool schemas use ``$ref``/``$defs`` references,
+    ``additionalProperties``, and ``anyOf`` null branches, which Gemini's
+    function-declaration schema rejects. This inlines references, flattens
+    single-element ``allOf`` wrappers, converts Optional to ``nullable``, and
+    drops unsupported keywords.
+    """
+    if defs is None:
+        defs = schema.get("$defs", {}) if isinstance(schema, dict) else {}
+
+    if isinstance(schema, list):
+        return [_sanitize_schema(item, defs, seen) for item in schema]
+    if not isinstance(schema, dict):
+        return schema
+
+    # Inline ``$ref`` (merging any sibling keys over the referenced schema).
+    ref = schema.get("$ref")
+    if isinstance(ref, str):
+        siblings = {k: v for k, v in schema.items() if k != "$ref"}
+        target = _resolve_ref(ref, defs)
+        if target is None or ref in seen:
+            # Unresolvable or recursive reference -> generic object fallback.
+            merged, next_seen = {"type": "object", **siblings}, seen
+        else:
+            merged, next_seen = {**target, **siblings}, seen | {ref}
+        return _sanitize_schema(merged, defs, next_seen)
+
+    # Flatten a single-element ``allOf`` wrapper (common Pydantic pattern).
+    all_of = schema.get("allOf")
+    if isinstance(all_of, list) and len(all_of) == 1 and isinstance(all_of[0], dict):
+        merged = {**all_of[0], **{k: v for k, v in schema.items() if k != "allOf"}}
+        return _sanitize_schema(merged, defs, seen)
+
+    # Convert Pydantic's Optional pattern (``anyOf`` with a null branch) to ``nullable``.
+    optional = _normalize_optional(schema)
+    if optional is not None:
+        return _sanitize_schema(optional, defs, seen)
+
+    return {
+        key: _sanitize_schema(value, defs, seen)
+        for key, value in schema.items()
+        if key not in _GEMINI_UNSUPPORTED_SCHEMA_KEYS
+    }
+
+
+def _extract_json_schema(response_format: dict[str, Any]) -> dict[str, Any] | None:
+    """Return the JSON Schema from an OpenAI-style ``json_schema`` response_format."""
+    json_schema = response_format.get("json_schema")
+    if isinstance(json_schema, dict) and isinstance(json_schema.get("schema"), dict):
+        return json_schema["schema"]
+    schema = response_format.get("schema")
+    if isinstance(schema, dict):
+        return schema
+    return None
+
+
+def _build_function_declarations(tools: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    """Convert OpenAI-style function tools → Gemini ``functionDeclarations``."""
+    declarations: list[dict[str, Any]] = []
+    for tool in tools:
+        if not isinstance(tool, dict) or tool.get("type") != "function":
+            continue
+        function = tool.get("function")
+        if not isinstance(function, dict):
+            continue
+        name = function.get("name")
+        if not name:
+            continue
+        declaration: dict[str, Any] = {"name": name}
+        description = function.get("description")
+        if description:
+            declaration["description"] = description
+        parameters = function.get("parameters")
+        if isinstance(parameters, dict) and parameters:
+            declaration["parameters"] = _sanitize_schema(parameters)
+        declarations.append(declaration)
+    return declarations
+
+
+def _build_tool_config(tool_choice: Any) -> dict[str, Any] | None:
+    """Convert OpenAI-style ``tool_choice`` → Gemini ``toolConfig``."""
+    if tool_choice is None:
+        return None
+    mode: str | None = None
+    allowed_names: list[str] | None = None
+    if isinstance(tool_choice, str):
+        mode = _TOOL_CHOICE_MODE_MAP.get(tool_choice.strip().lower())
+    elif isinstance(tool_choice, dict):
+        function = tool_choice.get("function")
+        if isinstance(function, dict) and function.get("name"):
+            mode = "ANY"
+            allowed_names = [function["name"]]
+    if mode is None:
+        return None
+    config: dict[str, Any] = {"mode": mode}
+    if allowed_names:
+        config["allowedFunctionNames"] = allowed_names
+    return {"functionCallingConfig": config}
+
+
+def _apply_tools(body: dict[str, Any], request: Request) -> None:
+    """Attach Gemini ``tools``/``toolConfig`` to *body* from the request."""
+    if not request.tools:
+        return
+    declarations = _build_function_declarations(request.tools)
+    if not declarations:
+        return
+    body["tools"] = [{"functionDeclarations": declarations}]
+    tool_config = _build_tool_config(request.options.get("tool_choice"))
+    if tool_config is not None:
+        body["toolConfig"] = tool_config
+
+
+def _coerce_args(arguments: str | dict[str, Any] | None) -> dict[str, Any]:
+    """Return a JSON object for a Gemini ``functionCall.args`` field.
+
+    Internal ``arguments`` follow the OpenAI convention (a JSON string), while
+    Gemini expects a JSON object.
+    """
+    if isinstance(arguments, dict):
+        return arguments
+    if isinstance(arguments, str) and arguments.strip():
+        try:
+            parsed = json.loads(arguments)
+        except (ValueError, TypeError):
+            return {}
+        if isinstance(parsed, dict):
+            return parsed
+    return {}
+
+
+def _coerce_response(result: Any) -> dict[str, Any]:
+    """Return a JSON object for a Gemini ``functionResponse.response`` field."""
+    if isinstance(result, dict):
+        return result
+    if isinstance(result, str) and result.strip():
+        try:
+            parsed = json.loads(result)
+        except (ValueError, TypeError):
+            return {"result": result}
+        if isinstance(parsed, dict):
+            return parsed
+        return {"result": parsed}
+    return {"result": result}
+
+
+def _map_role(role: str) -> str:
+    """Map internal roles to Gemini's ``user``/``model`` role set."""
+    if role == "assistant":
+        return "model"
+    if role == "tool":
+        return "user"
+    return role
+
+
+def _build_call_id_name_map(request: Request) -> dict[str, str]:
+    """Map ``call_id`` → function name from prior function_call items.
+
+    Gemini correlates a ``functionResponse`` by function name, but internal
+    ``function_result`` items may only carry the ``call_id``; this recovers the
+    name from the matching ``function_call``.
+    """
+    mapping: dict[str, str] = {}
+    for inp in request.inputs:
+        for c in inp.content:
+            if c.type == "function_call" and c.call_id and c.name:
+                mapping[c.call_id] = c.name
+    return mapping
+
+
+def _content_to_part(c: InputContent, call_id_to_name: dict[str, str]) -> dict[str, Any] | None:
+    """Convert a single ``InputContent`` to a Gemini content part."""
+    if c.type in ("input_text", "text") and c.text:
+        return {"text": c.text}
+    if c.type in ("input_image", "image") and c.image_base64:
+        return {
+            "inlineData": {
+                "mimeType": c.media_type or detect_media_type(base64_data=c.image_base64),
+                "data": c.image_base64,
+            },
+        }
+    if c.type in ("input_file", "file") and c.file_url:
+        return {
+            "fileData": {
+                "fileUri": c.file_url,
+                "mimeType": c.media_type or "application/octet-stream",
+            },
+        }
+    if c.type == "function_call":
+        return {"functionCall": {"name": c.name, "args": _coerce_args(c.arguments)}}
+    if c.type == "function_result":
+        name = c.name or call_id_to_name.get(c.call_id, "")
+        return {"functionResponse": {"name": name, "response": _coerce_response(c.result)}}
+    return None
+
+
+def _synthesize_call_id(name: str, index: int) -> str:
+    """Gemini responses omit a call id; synthesize a stable one for correlation."""
+    return f"gemini-{name or 'function'}-{index}"
+
 
 class GeminiAdapter(BaseAdapter):
     """Built-in adapter for Google Gemini generateContent API.
 
     Limitations:
     - Streaming not yet implemented (falls back to single response).
-    - Tool calls not yet supported.
     """
 
     @staticmethod
     def _validate_request(request: Request) -> None:
-        if request.tools:
-            raise ValueError("Gemini adapter does not support tools")
         if request.previous_response_id:
             raise ValueError("Gemini adapter does not support previous_response_id")
 
         response_format = request.options.get("response_format")
         if response_format is not None:
-            if not (isinstance(response_format, dict) and response_format.get("type") == "json_object"):
-                raise ValueError("Gemini adapter only supports response_format.type=json_object")
+            if not isinstance(response_format, dict):
+                raise ValueError("Gemini adapter response_format must be an object")
+            if response_format.get("type") not in ("json_object", "json_schema", "text"):
+                raise ValueError(
+                    "Gemini adapter supports response_format.type of json_object, json_schema, or text"
+                )
 
         for inp in request.inputs:
             for c in inp.content:
@@ -69,6 +314,8 @@ class GeminiAdapter(BaseAdapter):
                 if c.type in ("input_image", "image") and c.image_base64:
                     continue
                 if c.type in ("input_file", "file") and c.file_url:
+                    continue
+                if c.type in ("function_call", "function_result"):
                     continue
                 if c.type in ("input_image", "image") and c.image_url:
                     raise ValueError("Gemini adapter does not support remote image URLs")
@@ -122,13 +369,20 @@ class GeminiAdapter(BaseAdapter):
             generation_config["logprobs"] = top_logprobs
         if request.options.get("stop") is not None:
             generation_config["stopSequences"] = request.options["stop"]
-        if request.options.get("response_format") is not None:
-            resp_fmt = request.options["response_format"]
-            if isinstance(resp_fmt, dict) and resp_fmt.get("type") == "json_object":
+        response_format = request.options.get("response_format")
+        if isinstance(response_format, dict):
+            fmt_type = response_format.get("type")
+            if fmt_type in ("json_object", "json_schema"):
                 generation_config["responseMimeType"] = "application/json"
+            if fmt_type == "json_schema":
+                schema = _extract_json_schema(response_format)
+                if schema:
+                    generation_config["responseSchema"] = _sanitize_schema(schema)
 
         if generation_config:
             body["generationConfig"] = generation_config
+
+        _apply_tools(body, request)
 
         headers = {"Content-Type": "application/json"}
         headers.update(self._build_auth_headers(entry))
@@ -151,32 +405,19 @@ class GeminiAdapter(BaseAdapter):
     # ------------------------------------------------------------------
 
     def _build_contents(self, request: Request) -> list[dict[str, Any]]:
+        call_id_to_name = _build_call_id_name_map(request)
         contents: list[dict[str, Any]] = []
 
         for inp in request.inputs:
             parts: list[dict[str, Any]] = []
             for c in inp.content:
-                if c.type in ("input_text", "text") and c.text:
-                    parts.append({"text": c.text})
-                elif c.type in ("input_image", "image") and c.image_base64:
-                    parts.append({
-                        "inlineData": {
-                            "mimeType": c.media_type or detect_media_type(base64_data=c.image_base64),
-                            "data": c.image_base64,
-                        },
-                    })
-                elif c.type in ("input_file", "file") and c.file_url:
-                    parts.append({
-                        "fileData": {
-                            "fileUri": c.file_url,
-                            "mimeType": c.media_type or "application/octet-stream",
-                        },
-                    })
+                part = _content_to_part(c, call_id_to_name)
+                if part is not None:
+                    parts.append(part)
 
             if parts:
-                # Gemini uses "user"/"model" roles (not "assistant")
-                role = "model" if inp.role == "assistant" else inp.role
-                contents.append({"role": role, "parts": parts})
+                # Gemini uses "user"/"model" roles (not "assistant"/"tool").
+                contents.append({"role": _map_role(inp.role), "parts": parts})
 
         return contents
 
@@ -186,8 +427,21 @@ class GeminiAdapter(BaseAdapter):
         candidates = data.get("candidates", [])
         if candidates:
             content = candidates[0].get("content", {})
-            for part in content.get("parts", []):
-                if "text" in part:
+            for index, part in enumerate(content.get("parts", [])):
+                function_call = part.get("functionCall")
+                if function_call:
+                    name = function_call.get("name", "")
+                    args = function_call.get("args", {})
+                    arguments = json.dumps(args, ensure_ascii=False) if isinstance(args, dict) else str(args or "")
+                    outputs.append(
+                        OutputItem(
+                            type="function_call",
+                            call_id=_synthesize_call_id(name, index),
+                            name=name,
+                            arguments=arguments,
+                        )
+                    )
+                elif "text" in part:
                     outputs.append(OutputItem(type="text", text=part["text"]))
 
         usage_data = data.get("usageMetadata", {})

--- a/core/app/llmhubs/adapters/gemini.py
+++ b/core/app/llmhubs/adapters/gemini.py
@@ -25,6 +25,7 @@ Supports the Gemini generateContent REST API.
 
 from __future__ import annotations
 
+import copy
 import json
 import logging
 from typing import Any
@@ -46,8 +47,20 @@ _DEFAULT_BASE_URL = "https://generativelanguage.googleapis.com"
 # OpenAI-style ``tool_choice`` string → Gemini functionCallingConfig.mode.
 _TOOL_CHOICE_MODE_MAP = {"auto": "AUTO", "none": "NONE", "required": "ANY"}
 
-# JSON-Schema keywords Gemini's OpenAPI-subset schema rejects outright.
-_GEMINI_UNSUPPORTED_SCHEMA_KEYS = frozenset({"$schema", "$defs", "$ref", "additionalProperties"})
+# Fields Gemini's OpenAPI-subset ``Schema`` accepts (google-genai ``types.Schema``).
+# Anything else is dropped rather than forwarded, because Gemini rejects the whole
+# request when it sees an unknown field.
+_GEMINI_SCHEMA_ALLOWED_KEYS = frozenset(
+    {
+        "type", "format", "title", "description", "nullable", "default", "enum",
+        "items", "minItems", "maxItems",
+        "properties", "required", "propertyOrdering", "minProperties", "maxProperties",
+        "minimum", "maximum", "minLength", "maxLength", "pattern", "anyOf", "example",
+    }
+)
+# ``format`` values Gemini accepts; unsupported ones (email/uri/uuid/date/binary/...)
+# are dropped while the base ``type`` is kept.
+_GEMINI_ALLOWED_FORMATS = frozenset({"date-time", "int32", "int64", "float", "double"})
 
 
 def _resolve_ref(ref: str, defs: dict[str, Any]) -> dict[str, Any] | None:
@@ -79,6 +92,37 @@ def _normalize_optional(schema: dict[str, Any]) -> dict[str, Any] | None:
     return {**rest, "nullable": True}
 
 
+def _json_type_of(value: Any) -> str:
+    """Best-effort JSON-Schema ``type`` for a literal ``const`` value."""
+    if isinstance(value, bool):
+        return "boolean"
+    if isinstance(value, int):
+        return "integer"
+    if isinstance(value, float):
+        return "number"
+    return "string"
+
+
+def _reduce_to_gemini_fields(schema: dict[str, Any]) -> dict[str, Any]:
+    """Reduce one schema node to the fields Gemini's ``Schema`` accepts.
+
+    Converts a single-value ``const`` to ``enum`` (adding ``type`` when absent),
+    drops ``format`` values Gemini rejects while keeping the base ``type``, and
+    filters remaining keys against an explicit allowlist. Constraints Gemini
+    cannot represent (``exclusiveMinimum``/``exclusiveMaximum``, ``multipleOf``,
+    ``uniqueItems``, ...) fall outside the allowlist and are dropped.
+    """
+    reduced = dict(schema)
+    if "const" in reduced:
+        const_value = reduced.pop("const")
+        reduced.setdefault("enum", [const_value])
+        reduced.setdefault("type", _json_type_of(const_value))
+    fmt = reduced.get("format")
+    if isinstance(fmt, str) and fmt not in _GEMINI_ALLOWED_FORMATS:
+        reduced.pop("format")
+    return {key: value for key, value in reduced.items() if key in _GEMINI_SCHEMA_ALLOWED_KEYS}
+
+
 def _sanitize_schema(
     schema: Any,
     defs: dict[str, Any] | None = None,
@@ -86,11 +130,12 @@ def _sanitize_schema(
 ) -> Any:
     """Rewrite a JSON Schema into Gemini's supported subset.
 
-    Pydantic-generated tool schemas use ``$ref``/``$defs`` references,
-    ``additionalProperties``, and ``anyOf`` null branches, which Gemini's
-    function-declaration schema rejects. This inlines references, flattens
-    single-element ``allOf`` wrappers, converts Optional to ``nullable``, and
-    drops unsupported keywords.
+    Pydantic-generated schemas use ``$ref``/``$defs`` references, ``allOf``
+    wrappers, ``anyOf`` null branches, and keywords (``const``,
+    ``exclusiveMinimum``, unsupported ``format`` values, ...) that Gemini's
+    ``Schema`` rejects. This inlines references, flattens single-element
+    ``allOf`` wrappers, converts Optional to ``nullable`` and ``const`` to
+    ``enum``, and keeps only Gemini-supported fields (allowlist).
     """
     if defs is None:
         defs = schema.get("$defs", {}) if isinstance(schema, dict) else {}
@@ -123,11 +168,16 @@ def _sanitize_schema(
     if optional is not None:
         return _sanitize_schema(optional, defs, seen)
 
-    return {
-        key: _sanitize_schema(value, defs, seen)
-        for key, value in schema.items()
-        if key not in _GEMINI_UNSUPPORTED_SCHEMA_KEYS
-    }
+    reduced = _reduce_to_gemini_fields(schema)
+    result: dict[str, Any] = {}
+    for key, value in reduced.items():
+        # ``properties`` is a map of field-name -> schema; recurse into each
+        # sub-schema but keep the field names (they are not schema keywords).
+        if key == "properties" and isinstance(value, dict):
+            result[key] = {name: _sanitize_schema(sub, defs, seen) for name, sub in value.items()}
+        else:
+            result[key] = _sanitize_schema(value, defs, seen)
+    return result
 
 
 def _extract_json_schema(response_format: dict[str, Any]) -> dict[str, Any] | None:
@@ -294,8 +344,20 @@ def _function_call_part(c: InputContent) -> dict[str, Any]:
     """
     original = _gemini_original_part(c)
     if original is not None and "functionCall" in original:
-        return original
+        return copy.deepcopy(original)
     return {"functionCall": {"name": c.name, "args": _coerce_args(c.arguments)}}
+
+
+def _text_part(c: InputContent) -> dict[str, Any]:
+    """Build a Gemini text part.
+
+    Replays Gemini's original signed text Part verbatim (keeping its
+    ``thoughtSignature``) when captured; otherwise emits a plain text part.
+    """
+    original = _gemini_original_part(c)
+    if original is not None and "text" in original:
+        return copy.deepcopy(original)
+    return {"text": c.text}
 
 
 def _content_to_part(
@@ -305,7 +367,7 @@ def _content_to_part(
 ) -> dict[str, Any] | None:
     """Convert a single ``InputContent`` to a Gemini content part."""
     if c.type in ("input_text", "text") and c.text:
-        return {"text": c.text}
+        return _text_part(c)
     if c.type in ("input_image", "image") and c.image_base64:
         return {
             "inlineData": {
@@ -501,7 +563,10 @@ class GeminiAdapter(BaseAdapter):
                         )
                     )
                 elif "text" in part:
-                    outputs.append(OutputItem(type="text", text=part["text"]))
+                    # Preserve a signed thinking-text Part so its thoughtSignature
+                    # can be replayed verbatim (Gemini 3 requires it echoed back).
+                    provider_metadata = {"gemini": {"part": part}} if "thoughtSignature" in part else None
+                    outputs.append(OutputItem(type="text", text=part["text"], provider_metadata=provider_metadata))
 
         usage_data = data.get("usageMetadata", {})
         usage = Usage(

--- a/core/app/llmhubs/adapters/gemini.py
+++ b/core/app/llmhubs/adapters/gemini.py
@@ -255,7 +255,54 @@ def _build_call_id_name_map(request: Request) -> dict[str, str]:
     return mapping
 
 
-def _content_to_part(c: InputContent, call_id_to_name: dict[str, str]) -> dict[str, Any] | None:
+def _gemini_original_part(c: InputContent) -> dict[str, Any] | None:
+    """Return the original Gemini ``Part`` stashed in ``provider_metadata``, if any."""
+    provider_metadata = c.provider_metadata
+    if not isinstance(provider_metadata, dict):
+        return None
+    gemini = provider_metadata.get("gemini")
+    if not isinstance(gemini, dict):
+        return None
+    part = gemini.get("part")
+    return part if isinstance(part, dict) else None
+
+
+def _build_call_id_realid_map(request: Request) -> dict[str, str]:
+    """Map ``call_id`` → the real Gemini ``functionCall.id`` captured on the way in.
+
+    Only calls where Gemini actually issued an id are included; synthesized ids
+    are omitted so a fabricated id is never echoed back in a ``functionResponse``.
+    """
+    mapping: dict[str, str] = {}
+    for inp in request.inputs:
+        for c in inp.content:
+            if c.type != "function_call" or not c.call_id:
+                continue
+            part = _gemini_original_part(c)
+            real_id = part.get("functionCall", {}).get("id") if part else None
+            if real_id:
+                mapping[c.call_id] = real_id
+    return mapping
+
+
+def _function_call_part(c: InputContent) -> dict[str, Any]:
+    """Build a Gemini ``functionCall`` part.
+
+    Replays Gemini's original Part verbatim when it was captured (so its opaque
+    id / thoughtSignature survive the round trip); otherwise reconstructs from
+    the neutral fields (legacy / non-Gemini history).
+    """
+    original = _gemini_original_part(c)
+    if original is not None and "functionCall" in original:
+        return original
+    return {"functionCall": {"name": c.name, "args": _coerce_args(c.arguments)}}
+
+
+def _content_to_part(
+    c: InputContent,
+    call_id_to_name: dict[str, str],
+    call_id_to_real_id: dict[str, str],
+) -> dict[str, Any] | None:
     """Convert a single ``InputContent`` to a Gemini content part."""
     if c.type in ("input_text", "text") and c.text:
         return {"text": c.text}
@@ -274,10 +321,16 @@ def _content_to_part(c: InputContent, call_id_to_name: dict[str, str]) -> dict[s
             },
         }
     if c.type == "function_call":
-        return {"functionCall": {"name": c.name, "args": _coerce_args(c.arguments)}}
+        return _function_call_part(c)
     if c.type == "function_result":
         name = c.name or call_id_to_name.get(c.call_id, "")
-        return {"functionResponse": {"name": name, "response": _coerce_response(c.result)}}
+        response_part: dict[str, Any] = {"name": name, "response": _coerce_response(c.result)}
+        real_id = call_id_to_real_id.get(c.call_id)
+        if real_id:
+            # Echo the id Gemini issued so it can match this response to the
+            # correct call (disambiguates parallel calls to the same function).
+            response_part["id"] = real_id
+        return {"functionResponse": response_part}
     return None
 
 
@@ -406,12 +459,13 @@ class GeminiAdapter(BaseAdapter):
 
     def _build_contents(self, request: Request) -> list[dict[str, Any]]:
         call_id_to_name = _build_call_id_name_map(request)
+        call_id_to_real_id = _build_call_id_realid_map(request)
         contents: list[dict[str, Any]] = []
 
         for inp in request.inputs:
             parts: list[dict[str, Any]] = []
             for c in inp.content:
-                part = _content_to_part(c, call_id_to_name)
+                part = _content_to_part(c, call_id_to_name, call_id_to_real_id)
                 if part is not None:
                     parts.append(part)
 
@@ -436,9 +490,14 @@ class GeminiAdapter(BaseAdapter):
                     outputs.append(
                         OutputItem(
                             type="function_call",
-                            call_id=_synthesize_call_id(name, index),
+                            # Prefer the id Gemini issued; synthesize only as a
+                            # legacy fallback for models that omit it.
+                            call_id=function_call.get("id") or _synthesize_call_id(name, index),
                             name=name,
                             arguments=arguments,
+                            # Stash the original Part so its opaque id /
+                            # thoughtSignature can be replayed verbatim next turn.
+                            provider_metadata={"gemini": {"part": part}},
                         )
                     )
                 elif "text" in part:

--- a/core/app/llmhubs/adapters/gemini.py
+++ b/core/app/llmhubs/adapters/gemini.py
@@ -62,6 +62,11 @@ _GEMINI_SCHEMA_ALLOWED_KEYS = frozenset(
 # are dropped while the base ``type`` is kept.
 _GEMINI_ALLOWED_FORMATS = frozenset({"date-time", "int32", "int64", "float", "double"})
 
+# Schema keys whose values are literal data, not sub-schemas. They must be passed
+# through verbatim -- recursing would let the field allowlist strip non-keyword
+# data keys (e.g. an object-valued ``default`` would be reduced to ``{}``).
+_GEMINI_SCHEMA_DATA_KEYS = frozenset({"default", "example"})
+
 
 def _resolve_ref(ref: str, defs: dict[str, Any]) -> dict[str, Any] | None:
     """Resolve a ``#/$defs/Name`` reference against the collected definitions."""
@@ -89,10 +94,12 @@ def _normalize_optional(schema: dict[str, Any]) -> dict[str, Any] | None:
         return {**non_null[0], **rest, "nullable": True}
     if non_null:
         return {**rest, "anyOf": non_null, "nullable": True}
-    return {**rest, "nullable": True}
+    # Only null branches: unrepresentable (Gemini has no NULL type). Drop the
+    # ``anyOf`` to an unconstrained schema, matching ``Literal[None]`` -> ``{}``.
+    return rest
 
 
-def _json_type_of(value: Any) -> str:
+def _json_type_of(value: Any) -> str | None:
     """Best-effort JSON-Schema ``type`` for a literal ``const`` value."""
     if isinstance(value, bool):
         return "boolean"
@@ -100,23 +107,72 @@ def _json_type_of(value: Any) -> str:
         return "integer"
     if isinstance(value, float):
         return "number"
-    return "string"
+    if isinstance(value, str):
+        return "string"
+    return None
 
 
-def _reduce_to_gemini_fields(schema: dict[str, Any]) -> dict[str, Any]:
-    """Reduce one schema node to the fields Gemini's ``Schema`` accepts.
+def _normalize_const_and_enum(reduced: dict[str, Any]) -> None:
+    """Normalize ``const``/``enum`` to Gemini's string-only ``enum`` contract.
 
-    Converts a single-value ``const`` to ``enum`` (adding ``type`` when absent),
-    drops ``format`` values Gemini rejects while keeping the base ``type``, and
-    filters remaining keys against an explicit allowlist. Constraints Gemini
-    cannot represent (``exclusiveMinimum``/``exclusiveMaximum``, ``multipleOf``,
-    ``uniqueItems``, ...) fall outside the allowlist and are dropped.
+    ``const`` becomes a single-value ``enum`` (inferring ``type``). Gemini's
+    ``Schema.enum`` accepts strings only, so a non-string enum (``Literal[3]``,
+    ``IntEnum``, ``Literal[True]``, ``Literal[None]``) cannot be represented and
+    is dropped, keeping whatever base ``type`` was inferable.
     """
-    reduced = dict(schema)
     if "const" in reduced:
         const_value = reduced.pop("const")
         reduced.setdefault("enum", [const_value])
-        reduced.setdefault("type", _json_type_of(const_value))
+        inferred = _json_type_of(const_value)
+        if inferred is not None:
+            reduced.setdefault("type", inferred)
+    enum = reduced.get("enum")
+    if isinstance(enum, list) and not all(isinstance(entry, str) for entry in enum):
+        reduced.pop("enum", None)
+
+
+def _normalize_type(reduced: dict[str, Any]) -> None:
+    """Collapse a JSON-Schema ``type`` into Gemini's single-valued ``type``.
+
+    ``["string", "null"]`` becomes ``type: string`` + ``nullable: true``; a wider
+    union becomes ``anyOf``. A null-only ``type`` (scalar ``"null"`` or
+    ``["null"]``) is dropped, since Gemini's ``Schema.type`` has no NULL member.
+    """
+    type_value = reduced.get("type")
+    if type_value == "null":
+        types = ["null"]
+    elif isinstance(type_value, list):
+        types = type_value
+    else:
+        return
+    non_null = [entry for entry in types if entry != "null"]
+    if len(non_null) == 1:
+        reduced["type"] = non_null[0]
+    elif len(non_null) > 1:
+        reduced.pop("type", None)
+        reduced.setdefault("anyOf", [{"type": entry} for entry in non_null])
+    else:
+        reduced.pop("type", None)
+    if non_null and "null" in types:
+        reduced["nullable"] = True
+
+
+def _reduce_to_gemini_fields(schema: dict[str, Any]) -> dict[str, Any]:
+    """Reduce one schema node to the fields and value shapes Gemini's ``Schema`` accepts.
+
+    Converts ``oneOf`` to ``anyOf`` (Gemini has no ``oneOf``), normalizes
+    ``const``/``enum`` and ``type`` value shapes, drops ``format`` values Gemini
+    rejects while keeping the base ``type``, and filters remaining keys against an
+    explicit allowlist. Constraints Gemini cannot represent
+    (``exclusiveMinimum``/``exclusiveMaximum``, ``multipleOf``, ``uniqueItems``,
+    ...) fall outside the allowlist and are dropped.
+    """
+    reduced = dict(schema)
+    one_of = reduced.get("oneOf")
+    if isinstance(one_of, list) and "anyOf" not in reduced:
+        reduced["anyOf"] = one_of
+    _normalize_const_and_enum(reduced)
+    _normalize_type(reduced)
     fmt = reduced.get("format")
     if isinstance(fmt, str) and fmt not in _GEMINI_ALLOWED_FORMATS:
         reduced.pop("format")
@@ -171,9 +227,14 @@ def _sanitize_schema(
     reduced = _reduce_to_gemini_fields(schema)
     result: dict[str, Any] = {}
     for key, value in reduced.items():
-        # ``properties`` is a map of field-name -> schema; recurse into each
-        # sub-schema but keep the field names (they are not schema keywords).
-        if key == "properties" and isinstance(value, dict):
+        if key in _GEMINI_SCHEMA_DATA_KEYS:
+            # ``default``/``example`` hold literal data, not sub-schemas; pass
+            # them through verbatim (recursing would let the allowlist strip
+            # non-keyword data keys, e.g. reduce an object default to ``{}``).
+            result[key] = value
+        elif key == "properties" and isinstance(value, dict):
+            # ``properties`` is a map of field-name -> schema; recurse into each
+            # sub-schema but keep the field names (they are not schema keywords).
             result[key] = {name: _sanitize_schema(sub, defs, seen) for name, sub in value.items()}
         else:
             result[key] = _sanitize_schema(value, defs, seen)

--- a/core/app/llmhubs/adapters/gemini.py
+++ b/core/app/llmhubs/adapters/gemini.py
@@ -94,13 +94,15 @@ def _normalize_optional(schema: dict[str, Any]) -> dict[str, Any] | None:
         return {**non_null[0], **rest, "nullable": True}
     if non_null:
         return {**rest, "anyOf": non_null, "nullable": True}
-    # Only null branches: unrepresentable (Gemini has no NULL type). Drop the
-    # ``anyOf`` to an unconstrained schema, matching ``Literal[None]`` -> ``{}``.
-    return rest
+    # Only null branches: Gemini's ``Type`` enum includes ``NULL``, so preserve
+    # it as ``type: null`` instead of dropping the null requirement.
+    return {**rest, "type": "null"}
 
 
 def _json_type_of(value: Any) -> str | None:
     """Best-effort JSON-Schema ``type`` for a literal ``const`` value."""
+    if value is None:
+        return "null"
     if isinstance(value, bool):
         return "boolean"
     if isinstance(value, int):
@@ -132,45 +134,39 @@ def _normalize_const_and_enum(reduced: dict[str, Any]) -> None:
 
 
 def _normalize_type(reduced: dict[str, Any]) -> None:
-    """Collapse a JSON-Schema ``type`` into Gemini's single-valued ``type``.
+    """Collapse a JSON-Schema ``type`` array into Gemini's single-valued ``type``.
 
     ``["string", "null"]`` becomes ``type: string`` + ``nullable: true``; a wider
-    union becomes ``anyOf``. A null-only ``type`` (scalar ``"null"`` or
-    ``["null"]``) is dropped, since Gemini's ``Schema.type`` has no NULL member.
+    union becomes ``anyOf`` + ``nullable``. A null-only ``type`` (scalar ``"null"``
+    or ``["null"]``) is kept as ``type: null`` -- Gemini's ``Type`` enum includes
+    ``NULL``. A scalar ``type`` is already single-valued and is left untouched.
     """
     type_value = reduced.get("type")
-    if type_value == "null":
-        types = ["null"]
-    elif isinstance(type_value, list):
-        types = type_value
-    else:
+    if not isinstance(type_value, list):
         return
-    non_null = [entry for entry in types if entry != "null"]
+    non_null = [entry for entry in type_value if entry != "null"]
     if len(non_null) == 1:
         reduced["type"] = non_null[0]
     elif len(non_null) > 1:
         reduced.pop("type", None)
         reduced.setdefault("anyOf", [{"type": entry} for entry in non_null])
     else:
-        reduced.pop("type", None)
-    if non_null and "null" in types:
+        reduced["type"] = "null"
+    if non_null and "null" in type_value:
         reduced["nullable"] = True
 
 
 def _reduce_to_gemini_fields(schema: dict[str, Any]) -> dict[str, Any]:
     """Reduce one schema node to the fields and value shapes Gemini's ``Schema`` accepts.
 
-    Converts ``oneOf`` to ``anyOf`` (Gemini has no ``oneOf``), normalizes
-    ``const``/``enum`` and ``type`` value shapes, drops ``format`` values Gemini
-    rejects while keeping the base ``type``, and filters remaining keys against an
-    explicit allowlist. Constraints Gemini cannot represent
+    Normalizes ``const``/``enum`` and ``type`` value shapes, drops ``format``
+    values Gemini rejects while keeping the base ``type``, and filters remaining
+    keys against an explicit allowlist. Constraints Gemini cannot represent
     (``exclusiveMinimum``/``exclusiveMaximum``, ``multipleOf``, ``uniqueItems``,
-    ...) fall outside the allowlist and are dropped.
+    ...) fall outside the allowlist and are dropped. (``oneOf`` is rewritten to
+    ``anyOf`` earlier, in ``_sanitize_schema``.)
     """
     reduced = dict(schema)
-    one_of = reduced.get("oneOf")
-    if isinstance(one_of, list) and "anyOf" not in reduced:
-        reduced["anyOf"] = one_of
     _normalize_const_and_enum(reduced)
     _normalize_type(reduced)
     fmt = reduced.get("format")
@@ -218,6 +214,12 @@ def _sanitize_schema(
     if isinstance(all_of, list) and len(all_of) == 1 and isinstance(all_of[0], dict):
         merged = {**all_of[0], **{k: v for k, v in schema.items() if k != "allOf"}}
         return _sanitize_schema(merged, defs, seen)
+
+    # Gemini's ``Schema`` has no ``oneOf``; rewrite it as ``anyOf`` before the
+    # optional/null handling below so a nullable union collapses uniformly.
+    one_of = schema.get("oneOf")
+    if isinstance(one_of, list) and "anyOf" not in schema:
+        schema = {**{k: v for k, v in schema.items() if k != "oneOf"}, "anyOf": one_of}
 
     # Convert Pydantic's Optional pattern (``anyOf`` with a null branch) to ``nullable``.
     optional = _normalize_optional(schema)

--- a/core/app/llmhubs/chat_client.py
+++ b/core/app/llmhubs/chat_client.py
@@ -190,6 +190,16 @@ def _build_text_input(c: Any) -> InputContent | None:
     return InputContent(type="text", text=str(c.text))
 
 
+def _extract_provider_metadata(c: Any) -> dict[str, Any] | None:
+    """Pull an adapter's opaque ``provider_metadata`` back off a Content, if present."""
+    additional_properties = getattr(c, "additional_properties", None)
+    if isinstance(additional_properties, dict):
+        provider_metadata = additional_properties.get("provider_metadata")
+        if isinstance(provider_metadata, dict):
+            return provider_metadata
+    return None
+
+
 def _build_function_call_input(c: Any) -> InputContent:
     if c.name == "computer":
         actions: list[dict[str, Any]] | None = None
@@ -213,6 +223,7 @@ def _build_function_call_input(c: Any) -> InputContent:
         call_id=c.call_id,
         name=c.name,
         arguments=c.arguments,
+        provider_metadata=_extract_provider_metadata(c),
     )
 
 
@@ -434,10 +445,14 @@ def _output_refusal_to_content(output: OutputItem) -> Content | None:
 
 
 def _output_function_call_to_content(output: OutputItem) -> Content | None:
+    additional_properties = (
+        {"provider_metadata": output.provider_metadata} if output.provider_metadata else None
+    )
     return Content.from_function_call(
         call_id=output.call_id,
         name=output.name,
         arguments=output.arguments or "",
+        additional_properties=additional_properties,
     )
 
 

--- a/core/app/llmhubs/chat_client.py
+++ b/core/app/llmhubs/chat_client.py
@@ -187,7 +187,7 @@ def _scan_computer_call_ids(messages: MutableSequence[Message]) -> set[str]:
 def _build_text_input(c: Any) -> InputContent | None:
     if not c.text:
         return None
-    return InputContent(type="text", text=str(c.text))
+    return InputContent(type="text", text=str(c.text), provider_metadata=_extract_provider_metadata(c))
 
 
 def _extract_provider_metadata(c: Any) -> dict[str, Any] | None:
@@ -432,10 +432,12 @@ def _output_text_to_content(output: OutputItem) -> Content | None:
     if not (output.text or output.annotations):
         return None
     annotations = _parse_url_citations(output.annotations) if output.annotations else None
-    return Content.from_text(
-        text=output.text,
-        **({"annotations": annotations} if annotations else {}),
-    )
+    kwargs: dict[str, Any] = {}
+    if annotations:
+        kwargs["annotations"] = annotations
+    if output.provider_metadata:
+        kwargs["additional_properties"] = {"provider_metadata": output.provider_metadata}
+    return Content.from_text(text=output.text, **kwargs)
 
 
 def _output_refusal_to_content(output: OutputItem) -> Content | None:

--- a/core/app/llmhubs/config_loader.py
+++ b/core/app/llmhubs/config_loader.py
@@ -248,9 +248,10 @@ def _normalize_provider_template_type(value: Any) -> int:
 
 
 def _default_io_profile(model_type: int, provider_template_type: int) -> dict[str, Any]:
-    supports_tools = provider_template_type in (1, 2)
+    # Gemini (7) supports function calling and structured output via the GeminiAdapter.
+    supports_tools = provider_template_type in (1, 2, 7)
     supports_previous_response_id = provider_template_type in (1, 2)
-    supports_structured_output = provider_template_type in (1, 2)
+    supports_structured_output = provider_template_type in (1, 2, 7)
 
     if model_type == 2:
         return {

--- a/core/app/llmhubs/types.py
+++ b/core/app/llmhubs/types.py
@@ -42,6 +42,9 @@ class InputContent:
     result: Any | None = None
     output: dict[str, Any] | None = None  # computer_call_output nested data
     actions: list[dict[str, Any]] | None = None  # computer_call actions
+    # Opaque per-provider passthrough (e.g. the original Gemini ``Part``); shared
+    # layers only transport it, only the owning adapter interprets it.
+    provider_metadata: dict[str, Any] | None = None
 
 
 @dataclass
@@ -72,6 +75,9 @@ class OutputItem:
     actions: list[dict[str, Any]] | None = None  # computer_call actions
     annotations: list[dict[str, Any]] | None = None  # url_citation annotations
     action: dict[str, Any] | None = None  # web_search_call action metadata
+    # Opaque per-provider passthrough (e.g. the original Gemini ``Part``); shared
+    # layers only transport it, only the owning adapter interprets it.
+    provider_metadata: dict[str, Any] | None = None
 
 
 @dataclass

--- a/core/tests/llmhubs/test_gemini.py
+++ b/core/tests/llmhubs/test_gemini.py
@@ -616,22 +616,30 @@ def test_sanitize_schema_bool_const_drops_enum() -> None:
     assert _sanitize_schema({"const": True}) == {"type": "boolean"}
 
 
-def test_sanitize_schema_null_const_dropped() -> None:
-    # Literal[None] cannot be represented (no NULL type, no null enum); drop to an
-    # unconstrained schema rather than emit something Gemini rejects.
-    assert _sanitize_schema({"const": None}) == {}
+def test_sanitize_schema_null_const_becomes_null_type() -> None:
+    # Literal[None] -> {"const": None}. Gemini's Type enum includes NULL, so keep
+    # the null requirement as {"type": "null"} instead of dropping it.
+    assert _sanitize_schema({"const": None}) == {"type": "null"}
 
 
-def test_sanitize_schema_null_type_dropped() -> None:
-    # A null-only type (scalar "null" or ["null"]) has no Gemini Type member.
-    assert _sanitize_schema({"type": "null"}) == {}
-    assert _sanitize_schema({"type": ["null"]}) == {}
+def test_sanitize_schema_null_type_preserved() -> None:
+    # A null-only type (scalar "null" or ["null"]) is a valid Gemini Type.
+    assert _sanitize_schema({"type": "null"}) == {"type": "null"}
+    assert _sanitize_schema({"type": ["null"]}) == {"type": "null"}
 
 
-def test_sanitize_schema_all_null_anyof_dropped() -> None:
-    # An anyOf whose only branch is null is unrepresentable; drop to unconstrained
-    # rather than emit a bare {"nullable": true} with no base type.
-    assert _sanitize_schema({"anyOf": [{"type": "null"}]}) == {}
+def test_sanitize_schema_all_null_anyof_becomes_null_type() -> None:
+    # An anyOf whose only branch is null keeps the null requirement as type: null.
+    assert _sanitize_schema({"anyOf": [{"type": "null"}]}) == {"type": "null"}
+
+
+def test_sanitize_schema_nullable_oneof_becomes_nullable() -> None:
+    # oneOf is rewritten to anyOf; a string|null union collapses to a scalar type
+    # plus nullable, retaining the null option (not an unconstrained {} branch).
+    assert _sanitize_schema({"oneOf": [{"type": "string"}, {"type": "null"}]}) == {
+        "type": "string",
+        "nullable": True,
+    }
 
 
 def test_sanitize_schema_data_keys_preserved() -> None:

--- a/core/tests/llmhubs/test_gemini.py
+++ b/core/tests/llmhubs/test_gemini.py
@@ -606,8 +606,68 @@ def test_sanitize_schema_const_becomes_enum() -> None:
     assert _sanitize_schema({"const": "fixed"}) == {"enum": ["fixed"], "type": "string"}
 
 
-def test_sanitize_schema_const_infers_numeric_type() -> None:
-    assert _sanitize_schema({"const": 3}) == {"enum": [3], "type": "integer"}
+def test_sanitize_schema_numeric_const_drops_enum() -> None:
+    # Gemini's enum accepts strings only, so a numeric literal keeps its type
+    # but drops the (unrepresentable) enum constraint.
+    assert _sanitize_schema({"const": 3}) == {"type": "integer"}
+
+
+def test_sanitize_schema_bool_const_drops_enum() -> None:
+    assert _sanitize_schema({"const": True}) == {"type": "boolean"}
+
+
+def test_sanitize_schema_null_const_dropped() -> None:
+    # Literal[None] cannot be represented (no NULL type, no null enum); drop to an
+    # unconstrained schema rather than emit something Gemini rejects.
+    assert _sanitize_schema({"const": None}) == {}
+
+
+def test_sanitize_schema_null_type_dropped() -> None:
+    # A null-only type (scalar "null" or ["null"]) has no Gemini Type member.
+    assert _sanitize_schema({"type": "null"}) == {}
+    assert _sanitize_schema({"type": ["null"]}) == {}
+
+
+def test_sanitize_schema_all_null_anyof_dropped() -> None:
+    # An anyOf whose only branch is null is unrepresentable; drop to unconstrained
+    # rather than emit a bare {"nullable": true} with no base type.
+    assert _sanitize_schema({"anyOf": [{"type": "null"}]}) == {}
+
+
+def test_sanitize_schema_data_keys_preserved() -> None:
+    # default/example hold literal data, not sub-schemas; their (non-keyword)
+    # keys must survive rather than being stripped by the field allowlist.
+    schema = {"type": "object", "default": {"mode": "fast"}, "example": {"k": 1}}
+    assert _sanitize_schema(schema) == {
+        "type": "object",
+        "default": {"mode": "fast"},
+        "example": {"k": 1},
+    }
+
+
+def test_sanitize_schema_int_enum_drops_enum() -> None:
+    # IntEnum -> integer-valued enum, which Gemini's string-only enum rejects.
+    assert _sanitize_schema({"type": "integer", "enum": [1, 2, 3]}) == {"type": "integer"}
+
+
+def test_sanitize_schema_string_enum_kept() -> None:
+    assert _sanitize_schema({"type": "string", "enum": ["a", "b"]}) == {"type": "string", "enum": ["a", "b"]}
+
+
+def test_sanitize_schema_nullable_type_array() -> None:
+    assert _sanitize_schema({"type": ["string", "null"]}) == {"type": "string", "nullable": True}
+
+
+def test_sanitize_schema_multi_type_array_becomes_anyof() -> None:
+    assert _sanitize_schema({"type": ["string", "integer"]}) == {
+        "anyOf": [{"type": "string"}, {"type": "integer"}]
+    }
+
+
+def test_sanitize_schema_oneof_becomes_anyof() -> None:
+    assert _sanitize_schema({"oneOf": [{"type": "string"}, {"type": "integer"}]}) == {
+        "anyOf": [{"type": "string"}, {"type": "integer"}]
+    }
 
 
 def test_sanitize_schema_drops_exclusive_bounds() -> None:

--- a/core/tests/llmhubs/test_gemini.py
+++ b/core/tests/llmhubs/test_gemini.py
@@ -1,0 +1,411 @@
+# Copyright (c) 2026 Sico Authors
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+import json
+
+from app.llmhubs.adapters.gemini import (
+    GeminiAdapter,
+    _build_function_declarations,
+    _sanitize_schema,
+)
+from app.llmhubs.types import Input, InputContent, ModelRegistryEntry, Request
+
+
+def _has_key(node: object, key: str) -> bool:
+    """Return True if *key* appears anywhere in the nested dict/list *node*."""
+    if isinstance(node, dict):
+        if key in node:
+            return True
+        return any(_has_key(v, key) for v in node.values())
+    if isinstance(node, list):
+        return any(_has_key(v, key) for v in node)
+    return False
+
+
+def _model_entry(**config) -> ModelRegistryEntry:
+    return ModelRegistryEntry(
+        model_key="gemini-2.5-flash",
+        display_name="Gemini 2.5 Flash",
+        model_type=1,
+        provider_template_type=7,
+        config={"upstream_model_name": "gemini-2.5-flash", **config},
+        secrets={"api_key": "test-key"},
+    )
+
+
+_WEATHER_TOOL = {
+    "type": "function",
+    "function": {
+        "name": "get_weather",
+        "description": "Get the current weather for a city.",
+        "parameters": {
+            "type": "object",
+            "properties": {"city": {"type": "string"}},
+            "required": ["city"],
+        },
+    },
+}
+
+
+def test_prepare_request_builds_function_declarations_and_tool_config() -> None:
+    request = Request(
+        model="gemini-2.5-flash",
+        inputs=[Input(role="user", content=[InputContent(type="text", text="Weather in Tokyo?")])],
+        tools=[_WEATHER_TOOL],
+        options={"tool_choice": "auto"},
+    )
+
+    _url, body, _headers, _timeout = GeminiAdapter()._prepare_request(request, _model_entry())
+
+    assert body["tools"] == [
+        {
+            "functionDeclarations": [
+                {
+                    "name": "get_weather",
+                    "description": "Get the current weather for a city.",
+                    "parameters": {
+                        "type": "object",
+                        "properties": {"city": {"type": "string"}},
+                        "required": ["city"],
+                    },
+                }
+            ]
+        }
+    ]
+    assert body["toolConfig"] == {"functionCallingConfig": {"mode": "AUTO"}}
+
+
+def test_prepare_request_maps_specific_tool_choice_to_allowed_function_names() -> None:
+    request = Request(
+        model="gemini-2.5-flash",
+        inputs=[Input(role="user", content=[InputContent(type="text", text="hi")])],
+        tools=[_WEATHER_TOOL],
+        options={"tool_choice": {"type": "function", "function": {"name": "get_weather"}}},
+    )
+
+    _url, body, _headers, _timeout = GeminiAdapter()._prepare_request(request, _model_entry())
+
+    assert body["toolConfig"] == {"functionCallingConfig": {"mode": "ANY", "allowedFunctionNames": ["get_weather"]}}
+
+
+def test_prepare_request_without_tools_omits_tool_fields() -> None:
+    request = Request(
+        model="gemini-2.5-flash",
+        inputs=[Input(role="user", content=[InputContent(type="text", text="hi")])],
+    )
+
+    _url, body, _headers, _timeout = GeminiAdapter()._prepare_request(request, _model_entry())
+
+    assert "tools" not in body
+    assert "toolConfig" not in body
+
+
+def test_build_contents_maps_function_call_and_result() -> None:
+    request = Request(
+        model="gemini-2.5-flash",
+        inputs=[
+            Input(role="user", content=[InputContent(type="text", text="Weather in Tokyo?")]),
+            Input(
+                role="assistant",
+                content=[
+                    InputContent(
+                        type="function_call",
+                        call_id="call-1",
+                        name="get_weather",
+                        arguments='{"city": "Tokyo"}',
+                    )
+                ],
+            ),
+            Input(
+                role="tool",
+                content=[
+                    # ``function_result`` carries only the call_id; the name must be
+                    # recovered from the matching function_call.
+                    InputContent(
+                        type="function_result",
+                        call_id="call-1",
+                        result={"temperature": 30},
+                    )
+                ],
+            ),
+        ],
+    )
+
+    contents = GeminiAdapter()._build_contents(request)
+
+    assert contents == [
+        {"role": "user", "parts": [{"text": "Weather in Tokyo?"}]},
+        {
+            "role": "model",
+            "parts": [{"functionCall": {"name": "get_weather", "args": {"city": "Tokyo"}}}],
+        },
+        {
+            "role": "user",
+            "parts": [{"functionResponse": {"name": "get_weather", "response": {"temperature": 30}}}],
+        },
+    ]
+
+
+def test_build_contents_wraps_scalar_function_result() -> None:
+    request = Request(
+        model="gemini-2.5-flash",
+        inputs=[
+            Input(
+                role="tool",
+                content=[
+                    InputContent(
+                        type="function_result",
+                        call_id="call-1",
+                        name="get_weather",
+                        result="sunny",
+                    )
+                ],
+            ),
+        ],
+    )
+
+    contents = GeminiAdapter()._build_contents(request)
+
+    assert contents == [
+        {
+            "role": "user",
+            "parts": [{"functionResponse": {"name": "get_weather", "response": {"result": "sunny"}}}],
+        },
+    ]
+
+
+def test_parse_response_extracts_function_call() -> None:
+    data = {
+        "candidates": [
+            {
+                "content": {
+                    "role": "model",
+                    "parts": [{"functionCall": {"name": "get_weather", "args": {"city": "Tokyo"}}}],
+                }
+            }
+        ],
+        "usageMetadata": {"promptTokenCount": 5, "candidatesTokenCount": 7, "totalTokenCount": 12},
+    }
+
+    response = GeminiAdapter._parse_response(data)
+
+    assert len(response.outputs) == 1
+    output = response.outputs[0]
+    assert output.type == "function_call"
+    assert output.name == "get_weather"
+    assert json.loads(output.arguments) == {"city": "Tokyo"}
+    assert output.call_id == "gemini-get_weather-0"
+    assert response.usage.total_tokens == 12
+
+
+def test_parse_response_extracts_text() -> None:
+    data = {"candidates": [{"content": {"parts": [{"text": "hello"}]}}]}
+
+    response = GeminiAdapter._parse_response(data)
+
+    assert response.text == "hello"
+
+
+def test_validate_request_allows_tools() -> None:
+    request = Request(
+        model="gemini-2.5-flash",
+        inputs=[Input(role="user", content=[InputContent(type="text", text="hi")])],
+        tools=[_WEATHER_TOOL],
+    )
+
+    # Should not raise now that Gemini supports tools.
+    GeminiAdapter._validate_request(request)
+
+
+def test_sanitize_schema_inlines_refs_and_strips_unsupported_keys() -> None:
+    parameters = {
+        "type": "object",
+        "$defs": {
+            "Point": {
+                "type": "object",
+                "properties": {"x": {"type": "integer"}, "y": {"type": "integer"}},
+                "additionalProperties": False,
+            }
+        },
+        "properties": {
+            "origin": {"$ref": "#/$defs/Point"},
+            "tags": {"type": "array", "items": {"type": "string"}},
+        },
+        "required": ["origin"],
+        "additionalProperties": False,
+    }
+
+    decls = _build_function_declarations(
+        [{"type": "function", "function": {"name": "plot", "parameters": parameters}}]
+    )
+    params = decls[0]["parameters"]
+
+    # No unsupported keywords survive anywhere in the tree.
+    assert not _has_key(params, "$defs")
+    assert not _has_key(params, "$ref")
+    assert not _has_key(params, "additionalProperties")
+    # The reference was inlined.
+    assert params["properties"]["origin"]["type"] == "object"
+    assert params["properties"]["origin"]["properties"]["x"] == {"type": "integer"}
+    assert params["properties"]["tags"] == {"type": "array", "items": {"type": "string"}}
+    assert params["required"] == ["origin"]
+
+
+def test_sanitize_schema_flattens_single_allof() -> None:
+    schema = {
+        "type": "object",
+        "$defs": {"Inner": {"type": "object", "properties": {"n": {"type": "integer"}}}},
+        "properties": {
+            "field": {"allOf": [{"$ref": "#/$defs/Inner"}], "description": "an inner"},
+        },
+    }
+
+    out = _sanitize_schema(schema)
+    field = out["properties"]["field"]
+
+    assert field["type"] == "object"
+    assert field["description"] == "an inner"
+    assert field["properties"]["n"] == {"type": "integer"}
+    assert not _has_key(out, "$ref")
+
+
+def test_sanitize_schema_handles_recursive_ref() -> None:
+    schema = {
+        "type": "object",
+        "$defs": {"Node": {"type": "object", "properties": {"child": {"$ref": "#/$defs/Node"}}}},
+        "properties": {"root": {"$ref": "#/$defs/Node"}},
+    }
+
+    # Must terminate (no infinite recursion) and drop all refs/defs.
+    out = _sanitize_schema(schema)
+    assert not _has_key(out, "$ref")
+    assert not _has_key(out, "$defs")
+
+
+def test_prepare_request_maps_json_schema_response_format() -> None:
+    schema = {
+        "type": "object",
+        "$defs": {"Route": {"type": "string", "enum": ["fast", "task"]}},
+        "properties": {"route": {"$ref": "#/$defs/Route"}, "confidence": {"type": "number"}},
+        "required": ["route"],
+        "additionalProperties": False,
+    }
+    request = Request(
+        model="gemini-2.5-flash",
+        inputs=[Input(role="user", content=[InputContent(type="text", text="classify")])],
+        options={
+            "response_format": {
+                "type": "json_schema",
+                "json_schema": {"name": "Intent", "schema": schema, "strict": True},
+            }
+        },
+    )
+
+    _url, body, _headers, _timeout = GeminiAdapter()._prepare_request(request, _model_entry())
+    gen = body["generationConfig"]
+
+    assert gen["responseMimeType"] == "application/json"
+    response_schema = gen["responseSchema"]
+    assert not _has_key(response_schema, "$defs")
+    assert not _has_key(response_schema, "$ref")
+    assert not _has_key(response_schema, "additionalProperties")
+    # The ref was inlined into the response schema.
+    assert response_schema["properties"]["route"] == {"type": "string", "enum": ["fast", "task"]}
+    assert response_schema["required"] == ["route"]
+
+
+def test_prepare_request_json_object_sets_mime_only() -> None:
+    request = Request(
+        model="gemini-2.5-flash",
+        inputs=[Input(role="user", content=[InputContent(type="text", text="hi")])],
+        options={"response_format": {"type": "json_object"}},
+    )
+
+    _url, body, _headers, _timeout = GeminiAdapter()._prepare_request(request, _model_entry())
+    gen = body["generationConfig"]
+
+    assert gen["responseMimeType"] == "application/json"
+    assert "responseSchema" not in gen
+
+
+def test_validate_request_allows_json_schema_response_format() -> None:
+    request = Request(
+        model="gemini-2.5-flash",
+        inputs=[Input(role="user", content=[InputContent(type="text", text="hi")])],
+        options={"response_format": {"type": "json_schema", "json_schema": {"schema": {"type": "object"}}}},
+    )
+
+    # Should not raise now that Gemini supports structured output.
+    GeminiAdapter._validate_request(request)
+
+
+def test_sanitize_schema_optional_becomes_nullable() -> None:
+    schema = {
+        "type": "object",
+        "properties": {
+            "note": {"anyOf": [{"type": "string"}, {"type": "null"}], "description": "optional note"},
+        },
+    }
+
+    out = _sanitize_schema(schema)
+    note = out["properties"]["note"]
+
+    assert note["type"] == "string"
+    assert note["nullable"] is True
+    assert note["description"] == "optional note"
+    assert "anyOf" not in note
+
+
+def test_sanitize_schema_optional_ref_becomes_nullable() -> None:
+    schema = {
+        "type": "object",
+        "$defs": {"Point": {"type": "object", "properties": {"x": {"type": "integer"}}}},
+        "properties": {
+            "origin": {"anyOf": [{"$ref": "#/$defs/Point"}, {"type": "null"}]},
+        },
+    }
+
+    out = _sanitize_schema(schema)
+    origin = out["properties"]["origin"]
+
+    assert origin["type"] == "object"
+    assert origin["nullable"] is True
+    assert origin["properties"]["x"] == {"type": "integer"}
+    assert not _has_key(out, "$ref")
+    assert not _has_key(out, "$defs")
+
+
+def test_sanitize_schema_multi_union_with_null_keeps_anyof() -> None:
+    schema = {"anyOf": [{"type": "string"}, {"type": "integer"}, {"type": "null"}]}
+
+    out = _sanitize_schema(schema)
+
+    assert out["nullable"] is True
+    assert out["anyOf"] == [{"type": "string"}, {"type": "integer"}]
+    assert all(sub.get("type") != "null" for sub in out["anyOf"])
+
+
+def test_sanitize_schema_union_without_null_is_unchanged() -> None:
+    schema = {"anyOf": [{"type": "string"}, {"type": "integer"}]}
+
+    out = _sanitize_schema(schema)
+
+    assert out == {"anyOf": [{"type": "string"}, {"type": "integer"}]}
+    assert "nullable" not in out

--- a/core/tests/llmhubs/test_gemini.py
+++ b/core/tests/llmhubs/test_gemini.py
@@ -594,3 +594,179 @@ def test_chat_client_round_trips_provider_metadata() -> None:
     assert back.type == "function_call"
     assert back.call_id == "call_abc"
     assert back.provider_metadata == pm
+
+
+# ---------------------------------------------------------------------------
+# Schema sanitizer: allowlist + const/format handling (Comment 1)
+# ---------------------------------------------------------------------------
+
+
+def test_sanitize_schema_const_becomes_enum() -> None:
+    # Literal["fixed"] -> {"const": "fixed"}; Gemini has no const, so use enum.
+    assert _sanitize_schema({"const": "fixed"}) == {"enum": ["fixed"], "type": "string"}
+
+
+def test_sanitize_schema_const_infers_numeric_type() -> None:
+    assert _sanitize_schema({"const": 3}) == {"enum": [3], "type": "integer"}
+
+
+def test_sanitize_schema_drops_exclusive_bounds() -> None:
+    # Field(gt=0, lt=10) -> exclusiveMinimum/Maximum, which Gemini cannot represent.
+    out = _sanitize_schema({"type": "integer", "exclusiveMinimum": 0, "exclusiveMaximum": 10})
+    assert out == {"type": "integer"}
+
+
+def test_sanitize_schema_drops_unsupported_string_format() -> None:
+    # EmailStr -> {"type": "string", "format": "email"}; drop format, keep string.
+    out = _sanitize_schema({"type": "string", "format": "email"})
+    assert out == {"type": "string"}
+
+
+def test_sanitize_schema_keeps_supported_format() -> None:
+    assert _sanitize_schema({"type": "integer", "format": "int64"}) == {"type": "integer", "format": "int64"}
+    assert _sanitize_schema({"type": "string", "format": "date-time"}) == {"type": "string", "format": "date-time"}
+
+
+def test_sanitize_schema_drops_unrepresentable_keywords() -> None:
+    out = _sanitize_schema(
+        {
+            "type": "array",
+            "items": {"type": "number", "multipleOf": 2},
+            "uniqueItems": True,
+        }
+    )
+    assert out == {"type": "array", "items": {"type": "number"}}
+    assert not _has_key(out, "uniqueItems")
+    assert not _has_key(out, "multipleOf")
+
+
+def test_sanitize_schema_const_inside_properties_keeps_field_names() -> None:
+    schema = {
+        "type": "object",
+        "properties": {
+            "kind": {"const": "user"},
+            "name": {"type": "string"},
+        },
+        "required": ["kind"],
+    }
+
+    out = _sanitize_schema(schema)
+
+    # Field names under ``properties`` must survive the allowlist.
+    assert out["properties"]["kind"] == {"enum": ["user"], "type": "string"}
+    assert out["properties"]["name"] == {"type": "string"}
+    assert out["required"] == ["kind"]
+
+
+# ---------------------------------------------------------------------------
+# Signed text Part preserved + replayed (Comment 2)
+# ---------------------------------------------------------------------------
+
+
+def test_parse_response_preserves_signed_text_part() -> None:
+    data = {"candidates": [{"content": {"parts": [{"text": "Let me think.", "thoughtSignature": "TSIG"}]}}]}
+
+    out = GeminiAdapter._parse_response(data).outputs[0]
+
+    assert out.type == "text"
+    assert out.text == "Let me think."
+    assert out.provider_metadata["gemini"]["part"]["thoughtSignature"] == "TSIG"
+
+
+def test_parse_response_unsigned_text_has_no_provider_metadata() -> None:
+    data = {"candidates": [{"content": {"parts": [{"text": "hello"}]}}]}
+
+    out = GeminiAdapter._parse_response(data).outputs[0]
+
+    assert out.type == "text"
+    assert out.provider_metadata is None
+
+
+def test_content_to_part_replays_signed_text_part() -> None:
+    original = {"text": "Let me think.", "thoughtSignature": "TSIG"}
+    c = InputContent(type="text", text="Let me think.", provider_metadata={"gemini": {"part": original}})
+
+    assert _content_to_part(c, {}, {}) == original
+
+
+def test_two_turn_signed_text_plus_function_call() -> None:
+    # Gemini 3 turn: a signed thinking-text Part followed by a signed functionCall.
+    data = {
+        "candidates": [
+            {
+                "content": {
+                    "parts": [
+                        {"text": "I'll read the file.", "thoughtSignature": "T_TEXT"},
+                        {
+                            "functionCall": {"id": "call_1", "name": "read", "args": {"path": "a.txt"}},
+                            "thoughtSignature": "T_CALL",
+                        },
+                    ]
+                }
+            }
+        ]
+    }
+    outputs = GeminiAdapter._parse_response(data).outputs
+    assert [o.type for o in outputs] == ["text", "function_call"]
+
+    # Next-turn request: feed both model parts back plus a tool result.
+    request = Request(
+        inputs=[
+            Input(
+                role="assistant",
+                content=[
+                    InputContent(type="text", text=outputs[0].text, provider_metadata=outputs[0].provider_metadata),
+                    InputContent(
+                        type="function_call",
+                        call_id=outputs[1].call_id,
+                        name=outputs[1].name,
+                        arguments=outputs[1].arguments,
+                        provider_metadata=outputs[1].provider_metadata,
+                    ),
+                ],
+            ),
+            Input(
+                role="tool",
+                content=[InputContent(type="function_result", call_id="call_1", name="read", result={"ok": True})],
+            ),
+        ]
+    )
+
+    contents = GeminiAdapter()._build_contents(request)
+
+    model_parts = contents[0]["parts"]
+    # Both signed Parts replayed verbatim, as two distinct parts (not merged).
+    assert len(model_parts) == 2
+    assert model_parts[0] == {"text": "I'll read the file.", "thoughtSignature": "T_TEXT"}
+    assert model_parts[1]["functionCall"]["id"] == "call_1"
+    assert model_parts[1]["thoughtSignature"] == "T_CALL"
+    # Tool response echoes the real id.
+    assert contents[1]["parts"][0]["functionResponse"]["id"] == "call_1"
+
+
+def test_chat_client_round_trips_text_provider_metadata() -> None:
+    from app.llmhubs.chat_client import _build_text_input, _output_text_to_content
+
+    pm = {"gemini": {"part": {"text": "thinking", "thoughtSignature": "SIG"}}}
+    out = OutputItem(type="text", text="thinking", provider_metadata=pm)
+
+    content = _output_text_to_content(out)
+    assert content.additional_properties["provider_metadata"] == pm
+
+    back = _build_text_input(content)
+    assert back.type == "text"
+    assert back.provider_metadata == pm
+
+
+def test_content_to_part_replay_is_defensive_copy() -> None:
+    original = {"functionCall": {"id": "call_1", "name": "f", "args": {"x": 1}}, "thoughtSignature": "S"}
+    pm = {"gemini": {"part": original}}
+    c = InputContent(type="function_call", call_id="call_1", name="f", provider_metadata=pm)
+
+    part = _content_to_part(c, {}, {})
+    part["thoughtSignature"] = "MUTATED"
+    part["functionCall"]["args"]["x"] = 999
+
+    # Mutating the emitted part must not corrupt the stored provider_metadata.
+    assert pm["gemini"]["part"]["thoughtSignature"] == "S"
+    assert pm["gemini"]["part"]["functionCall"]["args"]["x"] == 1

--- a/core/tests/llmhubs/test_gemini.py
+++ b/core/tests/llmhubs/test_gemini.py
@@ -22,10 +22,13 @@ import json
 
 from app.llmhubs.adapters.gemini import (
     GeminiAdapter,
+    _build_call_id_name_map,
+    _build_call_id_realid_map,
     _build_function_declarations,
+    _content_to_part,
     _sanitize_schema,
 )
-from app.llmhubs.types import Input, InputContent, ModelRegistryEntry, Request
+from app.llmhubs.types import Input, InputContent, ModelRegistryEntry, OutputItem, Request
 
 
 def _has_key(node: object, key: str) -> bool:
@@ -409,3 +412,185 @@ def test_sanitize_schema_union_without_null_is_unchanged() -> None:
 
     assert out == {"anyOf": [{"type": "string"}, {"type": "integer"}]}
     assert "nullable" not in out
+
+
+# ---------------------------------------------------------------------------
+# Function-call id + thoughtSignature round trip (provider_metadata passthrough)
+# ---------------------------------------------------------------------------
+
+
+def test_parse_response_preserves_real_call_id_and_part() -> None:
+    data = {
+        "candidates": [
+            {
+                "content": {
+                    "parts": [
+                        {
+                            "functionCall": {
+                                "id": "call_abc",
+                                "name": "get_weather",
+                                "args": {"city": "Tokyo"},
+                            },
+                            "thoughtSignature": "SIGNATURE==",
+                        }
+                    ]
+                }
+            }
+        ]
+    }
+
+    resp = GeminiAdapter._parse_response(data)
+
+    assert len(resp.outputs) == 1
+    out = resp.outputs[0]
+    assert out.type == "function_call"
+    assert out.call_id == "call_abc"  # comment 1: real id preserved, not synthesized
+    assert out.name == "get_weather"
+    part = out.provider_metadata["gemini"]["part"]
+    assert part["functionCall"]["id"] == "call_abc"
+    assert part["thoughtSignature"] == "SIGNATURE=="  # comment 3: signature preserved
+
+
+def test_parse_response_synthesizes_call_id_when_missing() -> None:
+    data = {
+        "candidates": [
+            {"content": {"parts": [{"functionCall": {"name": "get_weather", "args": {"city": "Paris"}}}]}}
+        ]
+    }
+
+    resp = GeminiAdapter._parse_response(data)
+
+    out = resp.outputs[0]
+    assert out.call_id == "gemini-get_weather-0"  # legacy fallback
+    assert "id" not in out.provider_metadata["gemini"]["part"]["functionCall"]
+
+
+def test_content_to_part_replays_original_part_verbatim() -> None:
+    original = {
+        "functionCall": {"id": "call_abc", "name": "get_weather", "args": {"city": "Tokyo"}},
+        "thoughtSignature": "SIGNATURE==",
+    }
+    c = InputContent(
+        type="function_call",
+        call_id="call_abc",
+        name="get_weather",
+        arguments='{"city": "Tokyo"}',
+        provider_metadata={"gemini": {"part": original}},
+    )
+
+    part = _content_to_part(c, {}, {})
+
+    # comments 2/3: the original Part (id + thoughtSignature) is replayed unchanged.
+    assert part == original
+
+
+def test_content_to_part_reconstructs_when_no_provider_metadata() -> None:
+    c = InputContent(type="function_call", call_id="x", name="get_weather", arguments='{"city": "Tokyo"}')
+
+    part = _content_to_part(c, {}, {})
+
+    assert part == {"functionCall": {"name": "get_weather", "args": {"city": "Tokyo"}}}
+    assert "id" not in part["functionCall"]
+
+
+def test_function_response_echoes_real_id() -> None:
+    c = InputContent(type="function_result", call_id="call_abc", name="get_weather", result={"tempC": 20})
+
+    part = _content_to_part(c, {"call_abc": "get_weather"}, {"call_abc": "call_abc"})
+
+    assert part["functionResponse"]["name"] == "get_weather"
+    assert part["functionResponse"]["id"] == "call_abc"
+
+
+def test_function_response_omits_synthetic_id() -> None:
+    c = InputContent(type="function_result", call_id="gemini-get_weather-0", name="get_weather", result={"tempC": 20})
+
+    # No real-id mapping → this call had a synthesized id which must NOT be echoed.
+    part = _content_to_part(c, {}, {})
+
+    assert "id" not in part["functionResponse"]
+
+
+def test_build_call_id_realid_map_only_keeps_real_ids() -> None:
+    request = Request(
+        inputs=[
+            Input(
+                role="assistant",
+                content=[
+                    InputContent(
+                        type="function_call",
+                        call_id="call_abc",
+                        name="f",
+                        provider_metadata={"gemini": {"part": {"functionCall": {"id": "call_abc", "name": "f"}}}},
+                    ),
+                    InputContent(type="function_call", call_id="gemini-g-1", name="g"),  # synthesized, no part
+                ],
+            )
+        ]
+    )
+
+    assert _build_call_id_realid_map(request) == {"call_abc": "call_abc"}
+
+
+def test_parallel_same_function_calls_stay_distinct() -> None:
+    part_a = {"functionCall": {"id": "call_A", "name": "search", "args": {"q": "a"}}, "thoughtSignature": "SA"}
+    part_b = {"functionCall": {"id": "call_B", "name": "search", "args": {"q": "b"}}, "thoughtSignature": "SB"}
+    request = Request(
+        inputs=[
+            Input(
+                role="assistant",
+                content=[
+                    InputContent(
+                        type="function_call", call_id="call_A", name="search",
+                        arguments='{"q": "a"}', provider_metadata={"gemini": {"part": part_a}},
+                    ),
+                    InputContent(
+                        type="function_call", call_id="call_B", name="search",
+                        arguments='{"q": "b"}', provider_metadata={"gemini": {"part": part_b}},
+                    ),
+                ],
+            ),
+            Input(
+                role="tool",
+                content=[
+                    InputContent(type="function_result", call_id="call_A", name="search", result={"r": "a"}),
+                    InputContent(type="function_result", call_id="call_B", name="search", result={"r": "b"}),
+                ],
+            ),
+        ]
+    )
+    name_map = _build_call_id_name_map(request)
+    real_id_map = _build_call_id_realid_map(request)
+
+    # Assistant calls replay verbatim with their distinct ids + signatures.
+    assert _content_to_part(request.inputs[0].content[0], name_map, real_id_map) == part_a
+    assert _content_to_part(request.inputs[0].content[1], name_map, real_id_map) == part_b
+    # Each tool response carries the matching real id.
+    fr_a = _content_to_part(request.inputs[1].content[0], name_map, real_id_map)
+    fr_b = _content_to_part(request.inputs[1].content[1], name_map, real_id_map)
+    assert fr_a["functionResponse"]["id"] == "call_A"
+    assert fr_b["functionResponse"]["id"] == "call_B"
+
+
+def test_chat_client_round_trips_provider_metadata() -> None:
+    # End-to-end plumbing: OutputItem → agent_framework Content → InputContent.
+    # Also verifies agent_framework preserves Content.additional_properties.
+    from app.llmhubs.chat_client import _build_function_call_input, _output_function_call_to_content
+
+    pm = {
+        "gemini": {
+            "part": {
+                "functionCall": {"id": "call_abc", "name": "f", "args": {}},
+                "thoughtSignature": "SIG",
+            }
+        }
+    }
+    out = OutputItem(type="function_call", call_id="call_abc", name="f", arguments="{}", provider_metadata=pm)
+
+    content = _output_function_call_to_content(out)
+    assert content.additional_properties["provider_metadata"] == pm
+
+    back = _build_function_call_input(content)
+    assert back.type == "function_call"
+    assert back.call_id == "call_abc"
+    assert back.provider_metadata == pm


### PR DESCRIPTION
## Summary

Adds Google Gemini function/tool calling and JSON-schema structured output to the
LLMHub Gemini adapter, so Gemini models can drive the chat agent (tools) and
structured routing (intent check).

- **Tool calling**: map internal (OpenAI-shaped) `tools` / `function_call` /
  `function_result` to Gemini `functionDeclarations` / `functionCall` /
  `functionResponse` (role mapping `assistant→model` / `tool→user`, and
  `call_id`↔function-name correlation since Gemini responses carry no call id);
  parse Gemini `functionCall` back into `function_call` outputs.
- **Schema sanitizer**: rewrite tool/response JSON Schema into Gemini's
  OpenAPI-subset — inline `$ref`/`$defs`, drop `additionalProperties`/`$schema`,
  flatten single-element `allOf`, and convert Optional `anyOf` + `{"type":"null"}`
  to `nullable`.
- **Structured output**: map `response_format.type=json_schema` to Gemini
  `responseMimeType` + `responseSchema` (fixes chat intent-check routing on Gemini).
- **Capability flags**: advertise `supports_tools` / `supports_structured_output`
  for the Gemini provider (core `io_profile` derivation + backend equivalent).
- **Tests**: unit coverage for request building, input/response mapping, the
  sanitizer (refs/defs/additionalProperties/allOf/anyOf-null/recursion), and
  structured output.

## Validation

- [x] `make precommit-run`
- [x] `cd backend && go test ./...`
- [x] `cd core && uv run pytest`  <!-- 650 passed, 12 skipped -->
- [ ] Frontend build/lint, if working from a frontend source checkout
- [x] Not run; explain below

Frontend is untouched, so its build/lint does not apply.

## Checklist

- [ ] Linked relevant issues or explained why there is no issue.
- [x] Updated docs and examples where behavior changed.
- [x] Updated `CHANGELOG.md` under `## [Unreleased]` for user-facing changes.
- [x] Regenerated and committed generated files after proto, Wire, or OpenAPI changes.
- [x] Confirmed no secrets, tokens, credentials, or sensitive logs are included.

## Notes for reviewers

- **Streaming is not implemented for Gemini yet** — it falls back to the base
  non-streaming path (`generate_stream` yields a single chunk). Tool calling works,
  but without incremental token streaming; a follow-up can add
  `streamGenerateContent?alt=sse`.
- The schema sanitizer targets the keywords Gemini currently rejects; verified
  against the full builtin tool set and the structured intent-check schema.
- **No secrets/config included**: the local Gemini model YAML (with API key) and the
  local default-model switch are gitignored and intentionally excluded from this PR.