### PR TITLE
ci: pin ruff to 0.9.10 in Core Lint

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,7 +66,10 @@ jobs:
           cache: pip
 
       - name: Install ruff
-        run: pip install ruff
+        # Pin to the ruff version locked in core/uv.lock so CI lint stays
+        # reproducible. An unpinned install picks up new ruff releases whose
+        # expanded default rules flag pre-existing code and break unrelated PRs.
+        run: pip install ruff==0.9.10
 
       - name: Run ruff
         working-directory: core


### PR DESCRIPTION
## Problem

`Core Lint` fails on unrelated PRs (e.g. #55). The `core-lint` job installs ruff **unpinned**:

```yaml
- name: Install ruff
  run: pip install ruff
```

That pulls the latest ruff — currently **0.16.0** (released 2026-07-23) — whose expanded default rule set flags **289 pre-existing issues** across the existing suite (`BLE001`, `I001`, `UP037`, `RET501`, `PLR1711`, …), in files the failing PRs never touched. It reproduces on a clean `main` with the latest ruff, so it is unrelated to the PR under test.

## Fix

Pin CI to **ruff 0.9.10** — the version locked in `core/uv.lock` (matching the `ruff>=0.9.10` floor in `core/pyproject.toml`) that developers already use locally:

```yaml
- run: pip install ruff==0.9.10
```

## Validation

Locally with ruff 0.9.10:

```
$ cd core && ruff check .
All checks passed!
$ ruff check ../examples --config pyproject.toml
All checks passed!
```

Because `pull_request` runs use the workflow file from the PR branch, this PR's own `Core Lint` exercises the pinned ruff and should stay green.

## Follow-up (optional)

Bump ruff deliberately in a dedicated PR (update `core/uv.lock` + clear the newly-flagged issues) instead of relying on unpinned CI drift.
