### PR TITLE
fix(taskruntime): prevent duplicate stream replay

### DIFF
--- a/backend/internal/biz/conversation/impl/chat.go
+++ b/backend/internal/biz/conversation/impl/chat.go
@@ -30,6 +30,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/google/uuid"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 
@@ -820,6 +821,7 @@ func (s *Service) buildChatRequest(
 		Model:             resolveAgentModel(singleAgent),
 		AgentRole:         agentRole,
 		NeedUpdateTitle:   conversation.Title == DefaultConversationTitle,
+		SubmissionId:      uuid.NewString(),
 	}
 }
 

--- a/backend/internal/biz/conversation/impl/chat_test.go
+++ b/backend/internal/biz/conversation/impl/chat_test.go
@@ -27,6 +27,8 @@ import (
 
 	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 
 	"sico-backend/internal/biz/agent"
 	singleagententity "sico-backend/internal/entity/agent/singleagent"
@@ -276,4 +278,13 @@ func TestReconnect(t *testing.T) {
 		require.Len(t, sentEvents, 1)
 		require.Equal(t, "done", sentEvents[0].Event)
 	})
+}
+
+func TestShouldRetryCoreStreamChatStopsAfterOutput(t *testing.T) {
+	connection := &ChatConnection{}
+	err := status.Error(codes.Unavailable, "core disconnected")
+
+	require.True(t, shouldRetryCoreStreamChat(err, 1, connection))
+	connection.sentSeq = 1
+	require.False(t, shouldRetryCoreStreamChat(err, 1, connection))
 }

--- a/backend/internal/biz/conversation/impl/chat_test.go
+++ b/backend/internal/biz/conversation/impl/chat_test.go
@@ -288,3 +288,65 @@ func TestShouldRetryCoreStreamChatStopsAfterOutput(t *testing.T) {
 	connection.sentSeq = 1
 	require.False(t, shouldRetryCoreStreamChat(err, 1, connection))
 }
+
+// unavailableThenOKChatClient fails the first failAttempts StreamChat calls with
+// codes.Unavailable and records the submission id carried by every attempt.
+type unavailableThenOKChatClient struct {
+	conversationrpc.ChatServiceClient
+	failAttempts  int
+	calls         int
+	submissionIDs []string
+}
+
+func (m *unavailableThenOKChatClient) StreamChat(
+	ctx context.Context,
+	in *conversationdto.ChatRequest,
+	opts ...grpc.CallOption,
+) (*conversationdto.ChatDirectResponse, error) {
+	m.calls++
+	m.submissionIDs = append(m.submissionIDs, in.GetSubmissionId())
+	if m.calls <= m.failAttempts {
+		return nil, status.Error(codes.Unavailable, "core is draining")
+	}
+	return &conversationdto.ChatDirectResponse{}, nil
+}
+
+func newTestChatRequest(service *Service) *conversationdto.ChatRequest {
+	return service.buildChatRequest(
+		context.Background(),
+		&conversationdto.ChatRequestHttp{AgentInstanceID: 1, Message: "hi"},
+		"alice",
+		&singleagentpb.SingleAgent{},
+		nil,
+		&conventity.Conversation{ID: 7},
+		3,
+		nil,
+		nil,
+	)
+}
+
+func TestBuildChatRequestAssignsUniqueSubmissionID(t *testing.T) {
+	service := newTestConversationService()
+
+	first := newTestChatRequest(service)
+	second := newTestChatRequest(service)
+
+	require.NotEmpty(t, first.GetSubmissionId())
+	require.NotEqual(t, first.GetSubmissionId(), second.GetSubmissionId())
+}
+
+func TestStreamChatRetryReusesSubmissionID(t *testing.T) {
+	chatClient := &unavailableThenOKChatClient{failAttempts: 1}
+	service := newTestConversationService()
+	service.chatClient = chatClient
+	chatReq := newTestChatRequest(service)
+
+	err := service.streamChatWithUnavailableRetry(context.Background(), &ChatConnection{}, chatReq)
+
+	require.NoError(t, err)
+	require.Equal(t, 2, chatClient.calls)
+	require.NotEmpty(t, chatClient.submissionIDs[0])
+	// A transport-level retry must keep the identity so core treats the second
+	// attempt as a replay of the same submission rather than a new one.
+	require.Equal(t, chatClient.submissionIDs[0], chatClient.submissionIDs[1])
+}

--- a/backend/internal/store/taskruntime/internal/dal/errors.go
+++ b/backend/internal/store/taskruntime/internal/dal/errors.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 
 	"github.com/go-sql-driver/mysql"
+	"gorm.io/gorm"
 )
 
 // Stable error message tokens. Python clients translate by gRPC status code
@@ -48,6 +49,9 @@ func IsDuplicateKey(err error) bool {
 func isDuplicateKey(err error) bool {
 	if err == nil {
 		return false
+	}
+	if errors.Is(err, gorm.ErrDuplicatedKey) {
+		return true
 	}
 
 	var mysqlErr *mysql.MySQLError

--- a/backend/internal/store/taskruntime/internal/dal/errors_test.go
+++ b/backend/internal/store/taskruntime/internal/dal/errors_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/go-sql-driver/mysql"
+	"gorm.io/gorm"
 )
 
 func TestIsStaleTokenIdentifiesWrappedErrors(t *testing.T) {
@@ -44,6 +45,15 @@ func TestIsDuplicateKeyFallsBackOnMessage(t *testing.T) {
 	// classify it so the AlreadyExists mapping survives.
 	if !isDuplicateKey(errors.New("Error 1062 (23000): Duplicate entry 'x' for key 'uniq'")) {
 		t.Fatal("plain error with a 'Duplicate entry' message should be a duplicate key")
+	}
+}
+
+func TestIsDuplicateKeyHandlesTranslatedGORMError(t *testing.T) {
+	if !isDuplicateKey(gorm.ErrDuplicatedKey) {
+		t.Fatal("gorm.ErrDuplicatedKey should be a duplicate key")
+	}
+	if !isDuplicateKey(fmt.Errorf("create run: %w", gorm.ErrDuplicatedKey)) {
+		t.Fatal("wrapped gorm.ErrDuplicatedKey should be a duplicate key")
 	}
 }
 

--- a/backend/internal/transport/http/dto/conversation/api.pb.go
+++ b/backend/internal/transport/http/dto/conversation/api.pb.go
@@ -118,6 +118,7 @@ type ChatRequest struct {
 	AgentRole         string                 `protobuf:"bytes,15,opt,name=agent_role,json=agentRole,proto3" json:"agentRole,omitempty"`                            
 	ProjectName       string                 `protobuf:"bytes,16,opt,name=project_name,json=projectName,proto3" json:"projectName,omitempty"`                      
 	NeedUpdateTitle   bool                   `protobuf:"varint,17,opt,name=need_update_title,json=needUpdateTitle,proto3" json:"needUpdateTitle,omitempty"`       
+	SubmissionId      string                 `protobuf:"bytes,18,opt,name=submission_id,json=submissionId,proto3" json:"submissionId,omitempty"`                   
 	unknownFields     protoimpl.UnknownFields
 	sizeCache         protoimpl.SizeCache
 }
@@ -262,6 +263,13 @@ func (x *ChatRequest) GetNeedUpdateTitle() bool {
 		return x.NeedUpdateTitle
 	}
 	return false
+}
+
+func (x *ChatRequest) GetSubmissionId() string {
+	if x != nil {
+		return x.SubmissionId
+	}
+	return ""
 }
 
 type ChatDirectResponse struct {
@@ -1896,7 +1904,7 @@ var File_conversation_api_proto protoreflect.FileDescriptor
 
 const file_conversation_api_proto_rawDesc = "" +
 	"\n" +
-	"\x16conversation/api.proto\x12\x03api\x1a\x16conversation/msg.proto\x1a\x17conversation/plan.proto\x1a\x17conversation/chat.proto\x1a\x1fconversation/conversation.proto\x1a\x13common/common.proto\"\xda\x04\n" +
+	"\x16conversation/api.proto\x12\x03api\x1a\x16conversation/msg.proto\x1a\x17conversation/plan.proto\x1a\x17conversation/chat.proto\x1a\x1fconversation/conversation.proto\x1a\x13common/common.proto\"\xff\x04\n" +
 	"\vChatRequest\x12\x1a\n" +
 	"\busername\x18\x01 \x01(\tR\busername\x12+\n" +
 	"\amessage\x18\x02 \x01(\v2\x11.chat.ChatContentR\amessage\x12\x19\n" +
@@ -1917,7 +1925,8 @@ const file_conversation_api_proto_rawDesc = "" +
 	"\n" +
 	"agent_role\x18\x0f \x01(\tR\tagentRole\x12!\n" +
 	"\fproject_name\x18\x10 \x01(\tR\vprojectName\x12*\n" +
-	"\x11need_update_title\x18\x11 \x01(\bR\x0fneedUpdateTitle\"<\n" +
+	"\x11need_update_title\x18\x11 \x01(\bR\x0fneedUpdateTitle\x12#\n" +
+	"\rsubmission_id\x18\x12 \x01(\tR\fsubmissionId\"<\n" +
 	"\x12ChatDirectResponse\x12\x13\n" +
 	"\x04code\x18\xfd\x01 \x01(\x05R\x04code\x12\x11\n" +
 	"\x03msg\x18\xfe\x01 \x01(\tR\x03msg\"\xee\x01\n" +

--- a/core/app/biz/chat/chat.py
+++ b/core/app/biz/chat/chat.py
@@ -204,6 +204,22 @@ class ChatAgent:
                         len(prior_partial_messages),
                         exc_info=True,
                     )
+                    if self._tool_context is not None and self._tool_context.task_runtime_batch_ids:
+                        _LOGGER.warning(
+                            "chat_client_stream_retry_suppressed_after_task_submission "
+                            "agent_instance_id=%s conversation_id=%s turn_id=%s batch_ids=%s",
+                            self._agent_instance_id,
+                            conversation_id,
+                            options.turn_id,
+                            self._tool_context.task_runtime_batch_ids,
+                        )
+                        await queue.put(
+                            build_error_response(
+                                "Chat response generation stopped, but the submitted tasks are still running. "
+                                "Their progress and results remain available in the current plan."
+                            )
+                        )
+                        raise
                     error_text = f"Error with chat agent attempt {attempt}/{options.max_attempts}: {str(exc)}"
                     error_response = build_error_response(error_text)
                     error_message = Message(role="assistant", contents=[Content.from_text(error_text)])

--- a/core/app/biz/chat/service.py
+++ b/core/app/biz/chat/service.py
@@ -286,6 +286,7 @@ class ChatService(ChatServiceBase):
             response_queue=response_queue,
             plan_editor=plan_editor,
             raw_user_message=chat_request.message.content,
+            submission_id=chat_request.submission_id,
         )
 
         sequence_id = 0

--- a/core/app/biz/task_runtime/config.py
+++ b/core/app/biz/task_runtime/config.py
@@ -30,19 +30,19 @@ surfaced rather than silently swallowed. Two parsing strategies back them:
 * :func:`_resolve_positive_env` rejects non-positive values back to the default
   (concurrency ceilings).
 
-=======================================  ========  =====  ========
-Environment variable                     Default   Floor  Strategy
-=======================================  ========  =====  ========
-TASK_RUNTIME_REUSE_WAIT_TIMEOUT_SECONDS  policy+30  1     clamp
-TASK_RUNTIME_SANDBOX_RELEASE_ATTEMPTS    3         1      clamp
-TASK_RUNTIME_STALE_RUN_AFTER_MS          180000    0      clamp
-TASK_RUNTIME_RECONCILE_INTERVAL_SECONDS  30        1      clamp
-TASK_RUNTIME_HEARTBEAT_INTERVAL_SECONDS  30        1      clamp
-TASK_RUNTIME_REVERSE_RPC_TIMEOUT_SECONDS 20        1      clamp
-TASK_RUNTIME_MAX_CONCURRENCY             scheduler 1      reject
-TASK_RUNTIME_K8S_POD_CONCURRENCY         10        1      reject
-TASK_RUNTIME_DOCKER_CONCURRENCY          10        1      reject
-=======================================  ========  =====  ========
+===================================================  ==========  ======  ========
+Environment variable                                 Default     Floor   Strategy
+===================================================  ==========  ======  ========
+TASK_RUNTIME_REUSE_WAIT_TIMEOUT_SECONDS              policy+30   1       clamp
+TASK_RUNTIME_REPLAY_MATERIALIZATION_TIMEOUT_SECONDS  30          1       clamp
+TASK_RUNTIME_SANDBOX_RELEASE_ATTEMPTS                3           1       clamp
+TASK_RUNTIME_STALE_RUN_AFTER_MS                      180000      0       clamp
+TASK_RUNTIME_HEARTBEAT_INTERVAL_SECONDS              30          1       clamp
+TASK_RUNTIME_REVERSE_RPC_TIMEOUT_SECONDS             20          1       clamp
+TASK_RUNTIME_MAX_CONCURRENCY                         scheduler   1       reject
+TASK_RUNTIME_K8S_POD_CONCURRENCY                     10          1       reject
+TASK_RUNTIME_DOCKER_CONCURRENCY                      10          1       reject
+===================================================  ==========  ======  ========
 
 ``clamp`` raises sub-floor values up to ``floor``; ``reject`` reverts any value
 below 1 back to the default.
@@ -93,8 +93,8 @@ def _stale_run_after_ms() -> int:
     return _resolve_clamped_env("TASK_RUNTIME_STALE_RUN_AFTER_MS", 180000, floor=0)
 
 
-def _task_runtime_reconcile_interval_seconds() -> int:
-    return _resolve_clamped_env("TASK_RUNTIME_RECONCILE_INTERVAL_SECONDS", 30, floor=1)
+def _replay_run_materialization_timeout_seconds() -> int:
+    return _resolve_clamped_env("TASK_RUNTIME_REPLAY_MATERIALIZATION_TIMEOUT_SECONDS", 30, floor=1)
 
 
 def _task_runtime_heartbeat_interval_seconds() -> int:

--- a/core/app/biz/task_runtime/context.py
+++ b/core/app/biz/task_runtime/context.py
@@ -18,7 +18,7 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
-"""Per-turn identity + plan-editor envelope passed into TaskManager.
+"""Per-submission identity + plan-editor envelope passed into TaskManager.
 
 Used by ``TaskManager.submit_prepared`` as the narrow per-turn context for a
 single chat turn. Trusted handoff — fields are validated upstream by the
@@ -29,6 +29,7 @@ Carries only what ``submit_prepared`` and its descendants reach for:
 * identity fields (``username`` / ``agent_*`` / ``project_id`` /
   ``conversation_id`` / ``turn_id``)
 * ``plan_editor`` — streaming channel for lifecycle / tool-call UI updates
+* ``submission_id`` — stable identity for one logical task submission
 * ``task_runtime_batch_ids`` — mutable list shared with the source
   ``ToolContext`` tracking the batches this turn created.
 
@@ -64,6 +65,12 @@ class TurnContext:
     """Live channel for streaming task lifecycle updates to the frontend plan
     UI. Manager writes; tools/skills do not own this reference."""
 
+    submission_id: str = ""
+    """Stable identity for one logical task submission across transport retries."""
+
+    submission_source: str = ""
+    """Stable producer identity included in replay fingerprint validation."""
+
     task_runtime_batch_ids: list[str] = field(default_factory=list)
     """Append-only list of batch ids submitted during this turn. Mutated by
     the orchestrator on every successful ``submit_prepared``. When constructed via
@@ -71,15 +78,22 @@ class TurnContext:
     ``ToolContext`` so mutations propagate."""
 
     @classmethod
-    def from_tool_context(cls, tc: ToolContext) -> TurnContext:
+    def from_tool_context(
+        cls,
+        tc: ToolContext,
+        *,
+        submission_id: str = "",
+        submission_source: str = "",
+    ) -> TurnContext:
         """Narrow the wide ``ToolContext`` used inside chat tools into the
         per-turn context required by ``TaskManager.submit_prepared``.
 
         Drops ``response_queue`` / ``all_tools`` — those belong to tool
         execution, not to task scheduling. ``task_runtime_batch_ids`` shares
         the list reference so mutations from inside the manager propagate
-        back to the caller. Coerces ``agent_instance_id`` ``None`` to ``0``
-        so downstream code does not need a null check on every read."""
+        back to the caller. ``submission_id`` can be narrowed to one delegate
+        invocation. Coerces ``agent_instance_id`` ``None`` to ``0`` so downstream
+        code does not need a null check on every read."""
         return cls(
             username=tc.username,
             agent_id=tc.agent_id,
@@ -88,6 +102,8 @@ class TurnContext:
             conversation_id=tc.conversation_id,
             turn_id=tc.turn_id,
             plan_editor=tc.plan_editor,
+            submission_id=submission_id or tc.submission_id,
+            submission_source=submission_source,
             task_runtime_batch_ids=tc.task_runtime_batch_ids,
         )
 

--- a/core/app/biz/task_runtime/models.py
+++ b/core/app/biz/task_runtime/models.py
@@ -207,10 +207,9 @@ class TaskSpec(BaseModel):
     # hand-off). Gaps are allowed: distinct values are ordered ascending into
     # execution waves.
     stage: int = 0
-    # Optional caller-supplied idempotency key. When set, retrying with the
-    # exact same key (within the same turn) returns the prior run instead of
-    # creating a new one. When empty, the runtime derives a stable key from
-    # the task contents.
+    # Optional caller-supplied task identity within one logical submission.
+    # The runtime scopes it with the submission id and batch position, so a new
+    # user-requested submission still executes while transport replay reuses.
     idempotency_key: str = ""
 
     @field_validator("task_id", "title")
@@ -451,22 +450,23 @@ class BatchResultDigest(BaseModel):
         )
 
 
-def compute_idempotency_key(conversation_id: int, turn_id: int, batch_item_index: int, task: TaskSpec) -> str:
-    """Derive a stable idempotency key for a task within a conversation turn.
+def compute_idempotency_key(submission_id: str, batch_item_index: int, task: TaskSpec) -> str:
+    """Derive a stable task key within one logical submission.
 
-    The key intentionally excludes fields that change between retries (run/tool-call IDs,
-    timestamps, attempt counts). If the caller supplied an explicit ``task.idempotency_key``,
-    we trust it verbatim so callers can dedupe across turns. Otherwise we hash the
-    canonical contents of the task plus its position within the batch.
+    Transport retries preserve ``submission_id`` and therefore reuse existing
+    work. An intentional rerun receives a new submission id and executes again,
+    even when the task contents are unchanged.
     """
+    submission_id = submission_id.strip()
+    if not submission_id:
+        raise ValueError("submission_id is required")
+
     explicit = task.idempotency_key.strip()
-    if explicit:
-        return explicit
     payload = {
-        "conversation_id": conversation_id,
-        "turn_id": turn_id,
+        "schema_version": 2,
+        "submission_id": submission_id,
         "batch_item_index": batch_item_index,
-        "task": task.model_dump(
+        "task": {"explicit_idempotency_key": explicit} if explicit else task.model_dump(
             mode="json",
             exclude={"task_id", "idempotency_key", "metadata"},
             exclude_none=True,

--- a/core/app/biz/task_runtime/run_coordinator.py
+++ b/core/app/biz/task_runtime/run_coordinator.py
@@ -187,6 +187,12 @@ class RunCoordinator:
     # -- reuse path ---------------------------------------------------------
 
     async def _wait_for_existing_run(self, ctx: TurnContext, run: TaskRun) -> TaskResult:
+        # This path is an observer, not a replacement owner: claiming a queued
+        # run can allocate duplicate sandbox resources before fencing resolves,
+        # and a running external process cannot be resumed safely. If the owner
+        # died, its batch heartbeat expires and the stale reconciler persists a
+        # FAILED/BLOCKED result for us to observe. A local timeout is surfaced as
+        # BLOCKED rather than risking duplicate side effects.
         started_at = _now_ms()
         wait_timeout = _reuse_wait_timeout_seconds(run)
         deadline = time.monotonic() + wait_timeout

--- a/core/app/biz/task_runtime/stale_reconciler.py
+++ b/core/app/biz/task_runtime/stale_reconciler.py
@@ -39,7 +39,7 @@ from pathlib import Path
 
 from .results import aggregate, batch_results, persist_stranded_result, stranded_result
 from .models import TERMINAL_BATCH_STATUSES, TERMINAL_STATUSES
-from .config import _stale_run_after_ms
+from .config import _stale_run_after_ms, _task_runtime_heartbeat_interval_seconds
 from .context import TurnContext
 from .models import (
     BatchRecord,
@@ -100,6 +100,11 @@ def _plan_context_for_batch(ctx: TurnContext | None, batch: BatchRecord, runs: l
     from app.tools.plan import PlanEditor
 
     task_runtime_batch_ids = list(ctx.task_runtime_batch_ids) if ctx is not None else [batch.batch_id]
+    runtime_metadata = batch.metadata.get("_task_runtime", {})
+    submission_id = str(runtime_metadata.get("submission_id", "")) if isinstance(runtime_metadata, dict) else ""
+    submission_source = str(runtime_metadata.get("submission_source", "")) if isinstance(runtime_metadata, dict) else ""
+    if not submission_id:
+        submission_id = f"legacy:{batch.parent_conversation_id}:{batch.parent_turn_id}:{batch.batch_id}"
 
     return TurnContext(
         username=run.username,
@@ -108,6 +113,8 @@ def _plan_context_for_batch(ctx: TurnContext | None, batch: BatchRecord, runs: l
         turn_id=batch.parent_turn_id,
         project_id=run.project_id,
         conversation_id=conversation_id,
+        submission_id=submission_id,
+        submission_source=submission_source,
         plan_editor=PlanEditor(
             agent_instance_id=run.agent_instance_id,
             username=run.username,
@@ -361,22 +368,45 @@ async def reconcile_stale_task_runtime_once(
     await manager.reconcile_stale_runs()
 
 
-async def run_task_runtime_startup_reconciler() -> None:
-    """One-shot reconciliation invoked at core startup.
+def _startup_reconcile_delay_seconds() -> float:
+    stale_after_ms = _stale_run_after_ms()
+    if stale_after_ms <= 0:
+        return 0.0
+    return stale_after_ms / 1000 + _task_runtime_heartbeat_interval_seconds()
 
-    Recovers batches orphaned by a previous crash or unclean shutdown. Unlike the
-    previous continuous loop, this runs exactly once — live-process orphans (e.g.
-    heartbeat loss while the submitter is still running) are now handled by the
-    submitter's heartbeat self-abort mechanism, eliminating the race where the
-    reconciler and a live submitter both finalize the same batch.
-    """
+
+async def _run_startup_reconcile_pass(stage: str) -> None:
     try:
         await reconcile_stale_task_runtime_once()
     except Exception:
-        _LOGGER.warning("task runtime startup reconciliation failed", exc_info=True)
+        _LOGGER.warning("task runtime startup reconciliation failed stage=%s", stage, exc_info=True)
+
+
+async def run_task_runtime_startup_reconciler(stop_event: asyncio.Event) -> None:
+    """Run an immediate and one delayed crash-recovery pass after startup.
+
+    The immediate pass handles old orphans. A replacement pod normally starts
+    before its predecessor's heartbeat crosses the stale threshold, so one
+    delayed pass runs after that threshold plus a heartbeat safety margin. This
+    deliberately is not a permanent sweep loop: live owners retain liveness via
+    heartbeat, and recovery never executes cases or emits a recovered chat
+    message (``RECONCILER_RECOVERY_MESSAGE_ENABLED`` remains disabled).
+    """
+    await _run_startup_reconcile_pass("immediate")
+    delay_seconds = _startup_reconcile_delay_seconds()
+    if delay_seconds <= 0 or stop_event.is_set():
+        return
+    try:
+        await asyncio.wait_for(stop_event.wait(), timeout=delay_seconds)
+        return
+    except TimeoutError:
+        pass
+    if stop_event.is_set():
+        return
+    await _run_startup_reconcile_pass("delayed")
 
 
 # Keep the old name as a deprecated alias so any external callers don't break.
 async def run_task_runtime_reconciler(stop_event: asyncio.Event) -> None:
     """Deprecated: use :func:`run_task_runtime_startup_reconciler` instead."""
-    await run_task_runtime_startup_reconciler()
+    await run_task_runtime_startup_reconciler(stop_event)

--- a/core/app/biz/task_runtime/store.py
+++ b/core/app/biz/task_runtime/store.py
@@ -150,6 +150,8 @@ class FileRunStore:
 
     async def create_batch(self, batch: BatchRecord) -> None:
         batch_path = self.batch_dir(batch.batch_id)
+        if (batch_path / "batch.json").exists():
+            return
         batch_path.mkdir(parents=True, exist_ok=True)
         _write_json_atomic(batch_path / "batch.json", batch.model_dump(mode="json"))
 

--- a/core/app/biz/task_runtime/submitter.py
+++ b/core/app/biz/task_runtime/submitter.py
@@ -152,17 +152,19 @@ class Submitter:
         # own execution subtree in the plan (parent umbrella node + child run nodes).
         await self._progress.ensure_delegate_tasks_plan(ctx, prepared)
         parent_tool_call_id = await self._progress.create_delegate_tasks_call(ctx, prepared)
-        existing_batch = await self._get_existing_batch(_batch_id_for_submission(ctx.submission_id))
-        if existing_batch is not None:
-            try:
+        # The lookup itself is inside the guard: a failing store read (backend
+        # down, RPC timeout) must not leave the parent step stuck in "running".
+        try:
+            existing_batch = await self._get_existing_batch(_batch_id_for_submission(ctx.submission_id))
+            if existing_batch is not None:
                 _validate_submission_fingerprint_value(existing_batch, submission_fingerprint)
                 batch = existing_batch.model_copy(update={"parent_tool_call_id": parent_tool_call_id})
                 _record_context_batch_id(ctx, batch.batch_id)
                 return await self._observe_replayed_batch(ctx, batch, parent_tool_call_id)
-            except Exception:
-                with contextlib.suppress(Exception):
-                    await self._progress.mark_delegate_tasks_failed(ctx, parent_tool_call_id)
-                raise
+        except Exception:
+            with contextlib.suppress(Exception):
+                await self._progress.mark_delegate_tasks_failed(ctx, parent_tool_call_id)
+            raise
 
         execution_plan = await self._plan_batch_execution(ctx, prepared)
         batch = self._build_batch(

--- a/core/app/biz/task_runtime/submitter.py
+++ b/core/app/biz/task_runtime/submitter.py
@@ -32,47 +32,55 @@ from __future__ import annotations
 
 import asyncio
 import contextlib
+import hashlib
+import json
 import logging
 import uuid
 from collections.abc import AsyncIterator, Callable
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
-
-from .results import aggregate, finalize_nonterminal_runs, safe_list_batch_runs
+from .config import (
+    _replay_run_materialization_timeout_seconds,
+    _resolve_docker_concurrency,
+    _resolve_k8s_pod_concurrency,
+    _reuse_wait_timeout_seconds,
+    _stale_run_after_ms,
+    _task_runtime_heartbeat_interval_seconds,
+)
 from .context import TurnContext
-from .models import PreparedTaskBatch
+from .execution_plan import BatchExecutionPlan, SandboxTypePlan
+from .executors.command_backend import RESOURCE_KEY_DOCKER, RESOURCE_KEY_K8S_POD, backend_resource_key
 from .models import (
+    TERMINAL_BATCH_STATUSES,
+    TERMINAL_STATUSES,
     BatchRecord,
     BatchResult,
     BatchResultDigest,
     BatchStatus,
+    ErrorClass,
     JoinStrategy,
     SkillDispatch,
     TaskResult,
     TaskRun,
     TaskSpec,
     TaskStatus,
+    PreparedTaskBatch,
     compute_idempotency_key,
 )
+from .playbook_retrieval import attach_playbook_hints
+from .policy import _resolve_policy
 from .progress_port import RuntimeProgressPort
+from .presentation.rendering.batch_view import _planned_batch_sizes, _with_result_snapshots
+from .results import aggregate, finalize_nonterminal_runs, safe_list_batch_runs, terminal_result_from_run
 from .run_coordinator import RunCoordinator
 from .sandbox_coordinator import SandboxCoordinator
-from .config import (
-    _resolve_docker_concurrency, _resolve_k8s_pod_concurrency,
-    _stale_run_after_ms, _task_runtime_heartbeat_interval_seconds
-)
-from .executors.command_backend import RESOURCE_KEY_DOCKER, RESOURCE_KEY_K8S_POD, backend_resource_key
-from .tool_catalog import RUN_COMMAND_TOOL_NAME
-from .playbook_retrieval import attach_playbook_hints
-from .presentation.rendering.batch_view import _planned_batch_sizes, _with_result_snapshots
-from .execution_plan import BatchExecutionPlan, SandboxTypePlan
 from .sandbox_types import SANDBOX_OSES
 from .scheduler import BatchScheduler
 from .state_machine import transition_batch
 from .store import IdempotencyCollisionError, RunStore, _write_json_atomic
 from .time_utils import now_ms as _now_ms
-from .policy import _resolve_policy
+from .tool_catalog import RUN_COMMAND_TOOL_NAME
 
 if TYPE_CHECKING:
     from .skill_loader import SkillLoader
@@ -88,6 +96,7 @@ RUNTIME_METADATA_KEY = "_task_runtime"
 # warning. One miss is self-healing (the next beat recovers); a sustained run
 # means queued siblings will eventually be swept, so surface the cause once.
 _HEARTBEAT_FAILURE_WARN_THRESHOLD = 3
+_REPLAY_RESULT_POLL_SECONDS = 1.0
 
 
 class _HeartbeatDeathError(Exception):
@@ -133,16 +142,46 @@ class Submitter:
         *,
         batch_metadata: dict[str, Any],
     ) -> BatchResult:
+        if not ctx.submission_id.strip():
+            raise ValueError("task runtime submission_id is required")
         self._normalize_skill_required_sandbox(prepared)
-        execution_plan = await self._plan_batch_execution(ctx, prepared)
+        # Fingerprint the normalized batch before any capacity planning, so fleet
+        # availability changes cannot invalidate an otherwise identical replay.
+        submission_fingerprint = _prepared_submission_fingerprint(prepared, ctx.submission_source)
         # chat and runtime are peers: chat prepares the batch, the runtime owns its
         # own execution subtree in the plan (parent umbrella node + child run nodes).
         await self._progress.ensure_delegate_tasks_plan(ctx, prepared)
         parent_tool_call_id = await self._progress.create_delegate_tasks_call(ctx, prepared)
-        batch = self._build_batch(ctx, prepared, parent_tool_call_id, execution_plan, metadata=batch_metadata)
-        await self._store.create_batch(batch)
-        self._save_prepared_input(batch.batch_id, prepared)
-        _record_context_batch_id(ctx, batch.batch_id)
+        existing_batch = await self._get_existing_batch(_batch_id_for_submission(ctx.submission_id))
+        if existing_batch is not None:
+            try:
+                _validate_submission_fingerprint_value(existing_batch, submission_fingerprint)
+                batch = existing_batch.model_copy(update={"parent_tool_call_id": parent_tool_call_id})
+                _record_context_batch_id(ctx, batch.batch_id)
+                return await self._observe_replayed_batch(ctx, batch, parent_tool_call_id)
+            except Exception:
+                with contextlib.suppress(Exception):
+                    await self._progress.mark_delegate_tasks_failed(ctx, parent_tool_call_id)
+                raise
+
+        execution_plan = await self._plan_batch_execution(ctx, prepared)
+        batch = self._build_batch(
+            ctx,
+            prepared,
+            parent_tool_call_id,
+            execution_plan,
+            submission_fingerprint=submission_fingerprint,
+            metadata=batch_metadata,
+        )
+        try:
+            batch, is_replay = await self._materialize_batch(ctx, prepared, batch)
+            _record_context_batch_id(ctx, batch.batch_id)
+            if is_replay:
+                return await self._observe_replayed_batch(ctx, batch, parent_tool_call_id)
+        except Exception:
+            with contextlib.suppress(Exception):
+                await self._progress.mark_delegate_tasks_failed(ctx, parent_tool_call_id)
+            raise
         runs: list[TaskRun] = []
         try:
             runs = await self._create_runs(ctx, prepared, batch, parent_tool_call_id)
@@ -152,7 +191,7 @@ class Submitter:
                     ctx,
                     runs,
                     batch=batch,
-                    join_strategy=prepared.batch.join_strategy,
+                    join_strategy=batch.join_strategy,
                     execution_plan=execution_plan,
                 )
             await self._sandbox.cleanup_batch(ctx, batch)
@@ -182,11 +221,160 @@ class Submitter:
             )
             raise
         except asyncio.CancelledError:
-            await self._mark_batch_cancelled(ctx, batch, parent_tool_call_id, "Task runtime interrupted before completion.")
+            await self._mark_batch_cancelled(
+                ctx,
+                batch,
+                parent_tool_call_id,
+                "Task runtime interrupted before completion.",
+            )
             raise
         except Exception:
             await self._mark_batch_failed(ctx, batch, parent_tool_call_id)
             raise
+
+    async def _materialize_batch(
+        self,
+        ctx: TurnContext,
+        prepared: PreparedTaskBatch,
+        batch: BatchRecord,
+    ) -> tuple[BatchRecord, bool]:
+        await self._store.create_batch(batch)
+        persisted_batch = await self._store.get_batch(batch.batch_id)
+        if _batch_materialization_token(persisted_batch) != _batch_materialization_token(batch):
+            _validate_submission_fingerprint_value(
+                persisted_batch,
+                _batch_submission_fingerprint(batch),
+            )
+            _LOGGER.info(
+                "task submission replay detected submission_id=%s batch_id=%s",
+                ctx.submission_id,
+                batch.batch_id,
+            )
+            replay = persisted_batch.model_copy(update={"parent_tool_call_id": batch.parent_tool_call_id})
+            return replay, True
+
+        self._save_prepared_input(batch.batch_id, prepared)
+        return batch, False
+
+    async def _observe_replayed_batch(
+        self,
+        ctx: TurnContext,
+        batch: BatchRecord,
+        parent_tool_call_id: int,
+    ) -> BatchResult:
+        """Observe the original owner without taking liveness or persistence ownership.
+
+        A replay never heartbeats, claims, finalizes, cleans up, or updates the
+        shared batch. If the original process died, the normal stale reconciler
+        settles queued/running runs and this observer reports those terminal
+        FAILED/BLOCKED results rather than risking duplicate side effects.
+        """
+        runs = await self._reuse_existing_batch_runs(ctx, batch, parent_tool_call_id)
+        await self._progress.publish_parent_batch_progress(ctx, batch, runs)
+        results = await self._wait_for_replayed_batch_results(ctx, batch, runs)
+        batch_result = aggregate(
+            batch,
+            results,
+            artifacts_root=str(self._batch_dir(batch.batch_id)),
+        )
+        observed_batch = batch.model_copy(
+            update={
+                "status": batch_result.status,
+                "counts": BatchResultDigest.from_result(batch_result).counts,
+                "ended_at": batch.ended_at or _now_ms(),
+            }
+        )
+        final_runs = _with_result_snapshots(
+            self._merge_run_snapshots(runs, await self._store.list_batch_runs(batch.batch_id)),
+            results,
+        )
+        await self._progress.publish_parent_batch_progress(ctx, observed_batch, final_runs)
+        await self._progress.mark_parent_step_terminal_if_settled(
+            ctx,
+            parent_tool_call_id,
+            observed_batch.status,
+        )
+        return batch_result
+
+    async def _wait_for_replayed_batch_results(
+        self,
+        ctx: TurnContext,
+        batch: BatchRecord,
+        runs: list[TaskRun],
+    ) -> list[TaskResult]:
+        """Poll batch state once per interval and fetch each terminal result once.
+
+        This avoids one polling loop per run (hundreds of reverse RPCs per
+        second for large workbooks). Transient list/detail failures leave the
+        affected runs pending until the next batch poll.
+        """
+        if not runs:
+            raise RuntimeError(f"replayed batch {batch.batch_id} has no materialized runs")
+        loop = asyncio.get_running_loop()
+        observed_at = _now_ms()
+        wait_timeout = max(_reuse_wait_timeout_seconds(run) for run in runs)
+        deadline = loop.time() + wait_timeout
+        templates = {run.run_id: run for run in runs}
+        current_runs = dict(templates)
+        pending = set(templates)
+        results: dict[str, TaskResult] = {}
+
+        while pending and loop.time() < deadline:
+            try:
+                stored_runs = await self._store.list_batch_runs(batch.batch_id)
+            except Exception:
+                _LOGGER.debug("replayed batch state read failed batch_id=%s", batch.batch_id, exc_info=True)
+            else:
+                for stored in stored_runs:
+                    template = templates.get(stored.run_id)
+                    if template is None or stored.run_id not in pending:
+                        continue
+                    current = stored.model_copy(
+                        update={
+                            "parent_tool_call_id": template.parent_tool_call_id,
+                            "plan_batch_call_id": template.plan_batch_call_id,
+                        }
+                    )
+                    current_runs[stored.run_id] = current
+                    if stored.status not in TERMINAL_STATUSES:
+                        continue
+                    try:
+                        detail = await self._store.get_task_detail(stored.run_id, "summary")
+                    except Exception:
+                        _LOGGER.debug(
+                            "replayed run result read failed run_id=%s",
+                            stored.run_id,
+                            exc_info=True,
+                        )
+                        continue
+                    result = detail.result or terminal_result_from_run(detail.run)
+                    results[stored.run_id] = result
+                    pending.remove(stored.run_id)
+                    with contextlib.suppress(Exception):
+                        await self._progress.mark_run_terminal(ctx, current, result)
+            if pending:
+                await asyncio.sleep(_REPLAY_RESULT_POLL_SECONDS)
+
+        ended_at = _now_ms()
+        for run_id in pending:
+            run = current_runs[run_id]
+            result = TaskResult(
+                run_id=run.run_id,
+                task_id=run.spec.task_id,
+                status=TaskStatus.BLOCKED,
+                title=run.spec.title,
+                summary=f"Timed out waiting for prior run {run.run_id} to finish.",
+                error_class=ErrorClass.TRANSIENT,
+                error_message=f"Timed out waiting for prior run after {wait_timeout}s.",
+                started_at=observed_at,
+                ended_at=ended_at,
+                duration_ms=ended_at - observed_at,
+            )
+            results[run_id] = result
+            with contextlib.suppress(Exception):
+                await self._progress.mark_run_terminal(ctx, run, result)
+
+        return [results[run.run_id] for run in runs]
 
     # -- batch-level liveness ----------------------------------------------
 
@@ -510,6 +698,7 @@ class Submitter:
         parent_tool_call_id: int,
         execution_plan: BatchExecutionPlan,
         *,
+        submission_fingerprint: str,
         metadata: dict[str, Any] | None = None,
     ) -> BatchRecord:
         now_ms = _now_ms()
@@ -520,8 +709,12 @@ class Submitter:
         # columns only carry the representative bucket, so the per-type breakdown
         # (which fleet got how many lanes in a mixed android/windows batch) lives
         # here for diagnostics.
+        runtime_meta = dict(batch_metadata.get(RUNTIME_METADATA_KEY, {}))
+        runtime_meta["submission_id"] = ctx.submission_id
+        runtime_meta["submission_source"] = ctx.submission_source
+        runtime_meta["submission_fingerprint"] = submission_fingerprint
+        runtime_meta["materialization_token"] = uuid.uuid4().hex
         if execution_plan.sandbox_plans:
-            runtime_meta = dict(batch_metadata.get(RUNTIME_METADATA_KEY, {}))
             runtime_meta["sandbox_plans"] = [
                 {
                     "sandbox_type": plan.sandbox_type,
@@ -531,9 +724,9 @@ class Submitter:
                 }
                 for plan in execution_plan.sandbox_plans
             ]
-            batch_metadata[RUNTIME_METADATA_KEY] = runtime_meta
+        batch_metadata[RUNTIME_METADATA_KEY] = runtime_meta
         return BatchRecord(
-            batch_id=f"batch-{uuid.uuid4().hex[:12]}",
+            batch_id=_batch_id_for_submission(ctx.submission_id),
             parent_conversation_id=ctx.conversation_id,
             parent_turn_id=ctx.turn_id,
             parent_tool_call_id=parent_tool_call_id,
@@ -577,7 +770,7 @@ class Submitter:
             project_id=ctx.project_id,
             spec=task,
             execution_policy=policy,
-            idempotency_key=compute_idempotency_key(ctx.conversation_id, ctx.turn_id, batch_item_index, task),
+            idempotency_key=compute_idempotency_key(ctx.submission_id, batch_item_index, task),
             executor=policy.executor,
             queued_at=_now_ms(),
         )
@@ -600,10 +793,6 @@ class Submitter:
             )
             run = self._build_run(ctx, batch, task, parent_tool_call_id, child_tool_call_id, batch_item_index)
             await self._progress.mark_run_queued(ctx, run)
-            existing = await self._reuse_existing_run(ctx, run)
-            if existing is not None:
-                runs.append(existing)
-                continue
             try:
                 await self._store.create_run(run)
             except IdempotencyCollisionError:
@@ -614,11 +803,6 @@ class Submitter:
                 winner = await self._store.lookup_idempotent(run.idempotency_key)
                 if winner is None:
                     raise
-                if not _should_reuse_idempotent_run(winner, run):
-                    run.idempotency_key = _rerun_idempotency_key(run.idempotency_key, run.run_id)
-                    await self._store.create_run(run)
-                    runs.append(run)
-                    continue
                 winner = _bind_reused_run_to_current_plan(winner, run)
                 winner._runtime_reuse = True
                 runs.append(winner)
@@ -626,22 +810,65 @@ class Submitter:
             runs.append(run)
         return runs
 
-    async def _reuse_existing_run(self, ctx: TurnContext, run: TaskRun) -> TaskRun | None:
-        if not run.idempotency_key:
-            return None
+    async def _get_existing_batch(self, batch_id: str) -> BatchRecord | None:
         try:
-            existing = await self._store.lookup_idempotent(run.idempotency_key)
-        except Exception:
-            _LOGGER.warning("idempotent lookup failed for key=%s", run.idempotency_key, exc_info=True)
+            return await self._store.get_batch(batch_id)
+        except FileNotFoundError:
             return None
-        if existing is None:
-            return None
-        if not _should_reuse_idempotent_run(existing, run):
-            run.idempotency_key = _rerun_idempotency_key(run.idempotency_key, run.run_id)
-            return None
-        existing = _bind_reused_run_to_current_plan(existing, run)
-        existing._runtime_reuse = True
-        return existing
+
+    async def _reuse_existing_batch_runs(
+        self,
+        ctx: TurnContext,
+        batch: BatchRecord,
+        parent_tool_call_id: int,
+    ) -> list[TaskRun]:
+        timeout_seconds = _replay_run_materialization_timeout_seconds()
+        deadline = asyncio.get_running_loop().time() + timeout_seconds
+        stored_runs: list[TaskRun] = []
+        while True:
+            stored_runs = await self._store.list_batch_runs(batch.batch_id)
+            if len(stored_runs) >= batch.total_count or batch.status in TERMINAL_BATCH_STATUSES:
+                break
+            if asyncio.get_running_loop().time() >= deadline:
+                break
+            await asyncio.sleep(0.1)
+            batch = await self._store.get_batch(batch.batch_id)
+
+        expected_indices = set(range(batch.total_count))
+        actual_indices = {run.batch_item_index for run in stored_runs}
+        if len(stored_runs) != batch.total_count or actual_indices != expected_indices:
+            missing_indices = sorted(expected_indices - actual_indices)
+            _LOGGER.warning(
+                "replayed task submission incomplete batch_id=%s expected=%d found=%d "
+                "missing_indices=%s timeout_seconds=%d",
+                batch.batch_id,
+                batch.total_count,
+                len(stored_runs),
+                missing_indices,
+                timeout_seconds,
+            )
+            raise RuntimeError(
+                f"replayed task submission {batch.batch_id} expected {batch.total_count} materialized runs, "
+                f"found {len(stored_runs)}"
+            )
+
+        rebound: list[TaskRun] = []
+        for run in sorted(stored_runs, key=lambda item: item.batch_item_index):
+            child_tool_call_id = await self._progress.add_task_sub_call(
+                ctx,
+                parent_tool_call_id=parent_tool_call_id,
+                task=run.spec,
+                sub_call_index=run.batch_item_index,
+            )
+            current = run.model_copy(
+                update={
+                    "parent_tool_call_id": parent_tool_call_id,
+                    "plan_batch_call_id": child_tool_call_id,
+                }
+            )
+            current._runtime_reuse = True
+            rebound.append(current)
+        return rebound
 
     # -- abort / termination writers ---------------------------------------
 
@@ -825,15 +1052,54 @@ def _bind_reused_run_to_current_plan(existing: TaskRun, current: TaskRun) -> Tas
     )
 
 
-def _should_reuse_idempotent_run(existing: TaskRun, current: TaskRun) -> bool:
-    if existing.parent_conversation_id != current.parent_conversation_id:
-        return False
-    if existing.status == TaskStatus.COMPLETED:
-        return True
-    return existing.parent_turn_id == current.parent_turn_id
+def _batch_id_for_submission(submission_id: str) -> str:
+    digest = hashlib.sha256(submission_id.encode("utf-8")).hexdigest()[:24]
+    return f"batch-{digest}"
 
 
-def _rerun_idempotency_key(key: str, run_id: str) -> str:
-    if not key:
-        return key
-    return f"{key}:rerun:{run_id}"
+def _batch_materialization_token(batch: BatchRecord) -> str:
+    runtime_metadata = batch.metadata.get(RUNTIME_METADATA_KEY, {})
+    if not isinstance(runtime_metadata, dict):
+        return ""
+    return str(runtime_metadata.get("materialization_token", ""))
+
+
+def _prepared_submission_fingerprint(prepared: PreparedTaskBatch, submission_source: str = "") -> str:
+    payload = {
+        "submission_source": submission_source,
+        "tasks": [_task_execution_fingerprint_payload(task) for task in prepared.batch.tasks],
+        "join_strategy": prepared.batch.join_strategy,
+    }
+    canonical = json.dumps(payload, sort_keys=True, separators=(",", ":"), ensure_ascii=False)
+    return hashlib.sha256(canonical.encode("utf-8")).hexdigest()
+
+
+def _task_execution_fingerprint_payload(task: TaskSpec) -> dict[str, Any]:
+    return task.model_dump(
+        mode="json",
+        exclude={"display", "metadata"},
+        exclude_none=True,
+    )
+
+
+def _batch_submission_fingerprint(batch: BatchRecord) -> str:
+    runtime_metadata = batch.metadata.get(RUNTIME_METADATA_KEY, {})
+    if not isinstance(runtime_metadata, dict):
+        return ""
+    return str(runtime_metadata.get("submission_fingerprint", ""))
+
+
+def _validate_submission_fingerprint_value(existing: BatchRecord, incoming_fingerprint: str) -> None:
+    existing_fingerprint = _batch_submission_fingerprint(existing)
+    if existing_fingerprint and existing_fingerprint == incoming_fingerprint:
+        return
+    _LOGGER.warning(
+        "task submission replay diverged batch_id=%s existing_fingerprint=%s incoming_fingerprint=%s",
+        existing.batch_id,
+        existing_fingerprint[:12],
+        incoming_fingerprint[:12],
+    )
+    raise RuntimeError(
+        f"task submission replay diverged for batch {existing.batch_id}; "
+        "refusing to reuse results for regenerated tasks"
+    )

--- a/core/app/main.py
+++ b/core/app/main.py
@@ -137,7 +137,7 @@ async def serve():
     host, port = server_address.split(":")
     _LOGGER.info("Starting gRPC server at %s...", server_address)
 
-    task_runtime_reconciler = asyncio.create_task(run_task_runtime_startup_reconciler())
+    task_runtime_reconciler = asyncio.create_task(run_task_runtime_startup_reconciler(task_runtime_stop))
     sandbox_pod_reaper = asyncio.create_task(run_sandbox_pod_reaper(task_runtime_stop))
     try:
         await server.start(host, int(port))

--- a/core/app/pb/conversation/api/__init__.py
+++ b/core/app/pb/conversation/api/__init__.py
@@ -229,6 +229,11 @@ class ChatRequest(betterproto2.Message):
     @gotag: json:"needUpdateTitle,omitempty"
     """
 
+    submission_id: "str" = betterproto2.field(18, betterproto2.TYPE_STRING)
+    """
+    @gotag: json:"submissionId,omitempty"
+    """
+
 
 default_message_pool.register_message("api", "ChatRequest", ChatRequest)
 

--- a/core/app/tools/common.py
+++ b/core/app/tools/common.py
@@ -60,6 +60,25 @@ class ToolContext(BaseModel):
     raw_user_message: str = ""
     task_runtime_batch_ids: list[str] = Field(default_factory=list)
     skill_loader: Any | None = None
+    submission_id: str = ""
+    task_submission_index: int = Field(default=0, exclude=True)
+
+    def next_task_submission_id(self) -> str:
+        """Allocate the next delegate slot in this chat request.
+
+        A backend-to-core replay constructs a fresh context and starts again at
+        slot zero; fingerprint validation rejects changed work in an existing
+        slot. ChatAgent suppresses whole-generation retries after any task batch
+        is submitted; retries before submission have no batch to duplicate. The
+        retry prompt's instruction not to rerun successful tools remains an
+        additional safeguard. Different delegate calls, including identical
+        calls requested twice by the user, therefore receive independent batch
+        identities.
+        """
+        root = self.submission_id.strip() or f"legacy:{self.conversation_id}:{self.turn_id}"
+        index = self.task_submission_index
+        self.task_submission_index += 1
+        return f"{root}:delegate:{index}"
 
     def replace_plan_editor(self, new_plan_editor: PlanEditor) -> "ToolContext":
         return ToolContext(
@@ -75,6 +94,8 @@ class ToolContext(BaseModel):
             raw_user_message=self.raw_user_message,
             task_runtime_batch_ids=self.task_runtime_batch_ids,
             skill_loader=self.skill_loader,
+            submission_id=self.submission_id,
+            task_submission_index=self.task_submission_index,
         )
 
 

--- a/core/app/tools/delegate.py
+++ b/core/app/tools/delegate.py
@@ -156,7 +156,13 @@ def _build_delegate_tool(adapters: dict[str, Adapter]) -> FunctionTool:
                 "details": {"kind": kind, "valid_kinds": valid_kinds},
             }
         adapter_input = AdapterInput(options_json=str(kwargs.get("options_json", "") or ""))
-        return await _run_adapter(adapter, tool_context, adapter_input)
+        submission_id = tool_context.next_task_submission_id()
+        return await _run_adapter(
+            adapter,
+            tool_context,
+            adapter_input,
+            submission_id=submission_id,
+        )
 
     return FunctionTool(
         name=_DELEGATE_TOOL_NAME,
@@ -171,6 +177,8 @@ async def _run_adapter(
     adapter: Adapter,
     tool_context: ToolContext,
     adapter_input: AdapterInput,
+    *,
+    submission_id: str,
 ) -> dict[str, Any]:
     # Imported lazily to avoid a circular import via ``app.biz.chat.service``.
     from app.biz.task_runtime.context import TurnContext
@@ -215,7 +223,11 @@ async def _run_adapter(
                 task.model_dump_json(indent=2),
             )
 
-    turn_ctx = TurnContext.from_tool_context(tool_context)
+    turn_ctx = TurnContext.from_tool_context(
+        tool_context,
+        submission_id=submission_id,
+        submission_source=f"adapter:{adapter.name}",
+    )
     manager = default_task_manager(turn_ctx)
     try:
         batch_result = await manager.submit_prepared(turn_ctx, prepared)

--- a/core/tests/chat/test_chat.py
+++ b/core/tests/chat/test_chat.py
@@ -341,6 +341,53 @@ class TestChat:
 
 
 @pytest.mark.asyncio
+async def test_chat_agent_does_not_retry_generation_after_task_batch_created(mocker: pytest_mock.MockerFixture):
+    tool_context = ToolContext(
+        username="alice@example.com",
+        agent_id="agent-1",
+        agent_instance_id=628,
+        turn_id=2,
+        project_id=0,
+        conversation_id=787,
+        response_queue=asyncio.Queue(),
+        plan_editor=PlanEditor(agent_instance_id=628, username="alice@example.com", turn_id=2, conversation_id=787),
+        submission_id="request-1",
+    )
+    agent = ChatAgent(
+        client=FailingStreamingClient(),
+        username="alice@example.com",
+        agent_instance_id=628,
+        mem_runner=SimpleNamespace(),
+        tool_context=tool_context,
+    )
+    attempts = 0
+
+    async def fail_after_batch(*args, **kwargs):
+        nonlocal attempts
+        attempts += 1
+        tool_context.task_runtime_batch_ids.append("batch-1")
+        raise ConnectionError("stream failed after delegate submission")
+
+    mocker.patch.object(agent, "_stream_one_attempt", side_effect=fail_after_batch)
+    response_queue: asyncio.Queue[ChatResponse | ChatResponseUpdate | None] = asyncio.Queue()
+
+    with pytest.raises(ConnectionError, match="stream failed after delegate submission"):
+        await agent.run_stream(
+            response_queue,
+            AgentFrameworkMessage(role="user", contents=[Content.from_text("run")]),
+            "system",
+            options=RunOptions(max_attempts=2),
+        )
+
+    assert attempts == 1
+    error_response = await response_queue.get()
+    assert error_response is not None
+    error_text = error_response.content.content.lower()
+    assert "submitted tasks are still running" in error_text
+    assert "attempt 1/2" not in error_text
+
+
+@pytest.mark.asyncio
 async def test_chat_agent_persists_conversation_json_for_pre_stream_failure(tmp_path, monkeypatch):
     monkeypatch.setattr(chat_agent_module.CHAT_FS, "_root", tmp_path)
     monkeypatch.setattr(chat_agent_module, "get_context_length", lambda _model: 128_000)

--- a/core/tests/task_runtime/test_config.py
+++ b/core/tests/task_runtime/test_config.py
@@ -24,11 +24,11 @@ from app.biz.task_runtime.config import (
     DEFAULT_BACKEND_POD_CONCURRENCY,
     _resolve_clamped_env,
     _resolve_positive_env,
+    _replay_run_materialization_timeout_seconds,
     _reuse_wait_timeout_seconds,
     _sandbox_release_attempts,
     _stale_run_after_ms,
     _task_runtime_heartbeat_interval_seconds,
-    _task_runtime_reconcile_interval_seconds,
 )
 
 
@@ -147,10 +147,16 @@ def test_stale_run_after_ms_allows_zero_floor(monkeypatch) -> None:
     assert _stale_run_after_ms() == 0
 
 
-def test_reconcile_interval_default(monkeypatch) -> None:
-    monkeypatch.delenv("TASK_RUNTIME_RECONCILE_INTERVAL_SECONDS", raising=False)
+def test_replay_materialization_timeout_default(monkeypatch) -> None:
+    monkeypatch.delenv("TASK_RUNTIME_REPLAY_MATERIALIZATION_TIMEOUT_SECONDS", raising=False)
 
-    assert _task_runtime_reconcile_interval_seconds() == 30
+    assert _replay_run_materialization_timeout_seconds() == 30
+
+
+def test_replay_materialization_timeout_clamps_to_floor(monkeypatch) -> None:
+    monkeypatch.setenv("TASK_RUNTIME_REPLAY_MATERIALIZATION_TIMEOUT_SECONDS", "0")
+
+    assert _replay_run_materialization_timeout_seconds() == 1
 
 
 def test_heartbeat_interval_clamps_to_floor(monkeypatch) -> None:

--- a/core/tests/task_runtime/test_models.py
+++ b/core/tests/task_runtime/test_models.py
@@ -40,21 +40,21 @@ def test_idempotency_key_ignores_task_id() -> None:
     first = _skill_task("a", args={"case": {"id": 1}})
     second = _skill_task("b", args={"case": {"id": 1}})
 
-    assert compute_idempotency_key(100, 1, 3, first) == compute_idempotency_key(100, 1, 3, second)
+    assert compute_idempotency_key("submission-1", 3, first) == compute_idempotency_key("submission-1", 3, second)
 
 
-def test_idempotency_key_changes_with_conversation_id() -> None:
-     task = _skill_task("t", args={"a": 1})
-     assert compute_idempotency_key(1, 1, 0, task) != compute_idempotency_key(2, 1, 0, task)
+def test_idempotency_key_changes_with_submission_id() -> None:
+    task = _skill_task("t", args={"a": 1})
+
+    assert compute_idempotency_key("submission-1", 0, task) != compute_idempotency_key("submission-2", 0, task)
 
 
 def test_idempotency_key_is_stable_across_retries() -> None:
     """parent_tool_call_id may change on retry; the key must not."""
     task = _skill_task("t1", title="Same task", skill_name="s", args={"a": 1})
 
-    # Both calls have identical inputs (conversation_id + turn_id + batch_item_index + task contents).
-    key_first = compute_idempotency_key(100, 7, 0, task)
-    key_retry = compute_idempotency_key(100, 7, 0, task)
+    key_first = compute_idempotency_key("submission-1", 0, task)
+    key_retry = compute_idempotency_key("submission-1", 0, task)
 
     assert key_first == key_retry
 
@@ -63,13 +63,13 @@ def test_idempotency_key_changes_with_args() -> None:
     a = _skill_task("t", title="T", skill_name="s", args={"x": 1})
     b = _skill_task("t", title="T", skill_name="s", args={"x": 2})
 
-    assert compute_idempotency_key(100, 1, 0, a) != compute_idempotency_key(100, 1, 0, b)
+    assert compute_idempotency_key("submission-1", 0, a) != compute_idempotency_key("submission-1", 0, b)
 
 
-def test_explicit_idempotency_key_is_used_verbatim() -> None:
+def test_explicit_idempotency_key_is_scoped_to_submission() -> None:
     task = _skill_task("t", title="T", skill_name="s", idempotency_key="caller-supplied-uuid-123")
 
-    assert compute_idempotency_key(100, 99, 99, task) == "caller-supplied-uuid-123"
+    assert compute_idempotency_key("submission-1", 99, task) != compute_idempotency_key("submission-2", 99, task)
 
 
 def test_explicit_idempotency_key_overrides_args_changes() -> None:
@@ -77,7 +77,52 @@ def test_explicit_idempotency_key_overrides_args_changes() -> None:
     a = _skill_task("t", title="T", skill_name="s", args={"x": 1}, idempotency_key="job-42")
     b = _skill_task("t", title="T", skill_name="s", args={"x": 999}, idempotency_key="job-42")
 
-    assert compute_idempotency_key(100, 1, 0, a) == compute_idempotency_key(100, 1, 0, b)
+    assert compute_idempotency_key("submission-1", 0, a) == compute_idempotency_key("submission-1", 0, b)
+
+    without_explicit_key = _skill_task("t", title="T", skill_name="s", args={"x": 1})
+    assert compute_idempotency_key("submission-1", 0, a) != compute_idempotency_key(
+        "submission-1",
+        0,
+        without_explicit_key,
+    )
+
+
+def test_tool_context_assigns_stable_delegate_submission_ids_by_request_order() -> None:
+    context = ToolContext(
+        username="alice@example.com",
+        agent_id="agent",
+        agent_instance_id=1,
+        turn_id=7,
+        project_id=1,
+        conversation_id=100,
+        response_queue=asyncio.Queue(),
+        plan_editor=FakePlanEditor(),
+        submission_id="request-1",
+    )
+
+    first = context.next_task_submission_id()
+    second = context.next_task_submission_id()
+    third = context.next_task_submission_id()
+
+    assert (first, second, third) == (
+        "request-1:delegate:0",
+        "request-1:delegate:1",
+        "request-1:delegate:2",
+    )
+
+    replay = ToolContext(
+        username="alice@example.com",
+        agent_id="agent",
+        agent_instance_id=1,
+        turn_id=7,
+        project_id=1,
+        conversation_id=100,
+        response_queue=asyncio.Queue(),
+        plan_editor=FakePlanEditor(),
+        submission_id="request-1",
+    )
+    assert replay.next_task_submission_id() == first
+    assert replay.next_task_submission_id() == second
 
 
 def test_task_spec_dispatch_accessors_expose_dispatch_payload() -> None:

--- a/core/tests/task_runtime/test_stale_reconciler_startup.py
+++ b/core/tests/task_runtime/test_stale_reconciler_startup.py
@@ -1,0 +1,59 @@
+# Copyright (c) 2026 Sico Authors
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+import app.biz.task_runtime.stale_reconciler as stale_reconciler
+
+
+@pytest.mark.asyncio
+async def test_startup_reconciler_runs_immediate_and_delayed_pass(monkeypatch) -> None:
+    calls: list[str] = []
+
+    async def reconcile_once() -> None:
+        calls.append("reconcile")
+
+    monkeypatch.setattr(stale_reconciler, "reconcile_stale_task_runtime_once", reconcile_once)
+    monkeypatch.setattr(stale_reconciler, "_startup_reconcile_delay_seconds", lambda: 0.001)
+
+    await stale_reconciler.run_task_runtime_startup_reconciler(asyncio.Event())
+
+    assert calls == ["reconcile", "reconcile"]
+
+
+@pytest.mark.asyncio
+async def test_startup_reconciler_skips_delayed_pass_when_stopping(monkeypatch) -> None:
+    calls: list[str] = []
+
+    async def reconcile_once() -> None:
+        calls.append("reconcile")
+
+    monkeypatch.setattr(stale_reconciler, "reconcile_stale_task_runtime_once", reconcile_once)
+    monkeypatch.setattr(stale_reconciler, "_startup_reconcile_delay_seconds", lambda: 60)
+    stop_event = asyncio.Event()
+    stop_event.set()
+
+    await stale_reconciler.run_task_runtime_startup_reconciler(stop_event)
+
+    assert calls == ["reconcile"]

--- a/core/tests/task_runtime/test_submit_prepared.py
+++ b/core/tests/task_runtime/test_submit_prepared.py
@@ -158,6 +158,19 @@ def _tool_executor(tmp_path: Path) -> ToolExecutor:
     )
 
 
+class _FailingBatchLookupStore(FileRunStore):
+    """Simulates a store read that fails for a reason other than "not found"."""
+
+    def __init__(self, root: Path) -> None:
+        super().__init__(root)
+        self.fail_batch_lookup = False
+
+    async def get_batch(self, batch_id: str):
+        if self.fail_batch_lookup:
+            raise ConnectionError(f"simulated backend outage for {batch_id}")
+        return await super().get_batch(batch_id)
+
+
 class _CountingExecutor:
     def __init__(self, inner: Executor) -> None:
         self.inner = inner
@@ -391,3 +404,26 @@ async def test_replayed_batch_result_wait_rejects_empty_runs(tmp_path: Path) -> 
 
     with pytest.raises(RuntimeError, match="has no materialized runs"):
         await manager.submitter._wait_for_replayed_batch_results(context, batch, [])
+
+
+@pytest.mark.asyncio
+async def test_submit_prepared_marks_parent_failed_when_replay_lookup_errors(tmp_path: Path) -> None:
+    store = _FailingBatchLookupStore(tmp_path / "turn" / "results")
+    executor = _CountingExecutor(_tool_executor(tmp_path))
+    manager = TaskManager(store, executor, max_concurrency=1)
+    prepared = PreparedTaskBatch(
+        batch=TaskBatchInput(tasks=(_echo_task("task-1", "hello"),), description="Replay batch."),
+    )
+    failed_parent_calls: list[int] = []
+
+    async def record_failure(_ctx, parent_tool_call_id: int) -> None:
+        failed_parent_calls.append(parent_tool_call_id)
+
+    manager.submitter._progress.mark_delegate_tasks_failed = record_failure
+    store.fail_batch_lookup = True
+
+    with pytest.raises(ConnectionError, match="simulated backend outage"):
+        await manager.submit_prepared(_turn_context("submission-1"), prepared)
+
+    assert len(failed_parent_calls) == 1
+    assert executor.run_count == 0

--- a/core/tests/task_runtime/test_submit_prepared.py
+++ b/core/tests/task_runtime/test_submit_prepared.py
@@ -26,17 +26,20 @@ batches and preserves caller-supplied ``batch_metadata`` verbatim."""
 from __future__ import annotations
 
 from pathlib import Path
+import shutil
 from types import SimpleNamespace
 
 import pytest
 
 from app.biz.task_runtime.artifact_store import FileArtifactStore
+from app.biz.task_runtime.executors.base import Executor
 from app.biz.task_runtime.executors.command_backend import LocalBackend
-from app.biz.task_runtime.models import PreparedTaskBatch, TaskBatchInput
+from app.biz.task_runtime.models import PreparedTaskBatch, TaskBatchInput, TaskDisplay
 from app.biz.task_runtime.executors.tool_executor import ToolExecutor
 from app.biz.task_runtime.manager import TaskManager
 from app.biz.task_runtime.models import TaskSpec, ToolDispatch
 from app.biz.task_runtime.store import FileRunStore
+from app.biz.task_runtime.submitter import _prepared_submission_fingerprint
 from app.schemas.conversation.plan import Plan
 from app.biz.task_runtime.context import TurnContext
 from app.tools.plan import PlanEditor
@@ -98,7 +101,7 @@ class _FakePlanEditor(PlanEditor):
         return self.cancelled
 
 
-def _turn_context() -> TurnContext:
+def _turn_context(submission_id: str = "submission-1") -> TurnContext:
     return TurnContext(
         username="alice@example.com",
         agent_id="agent",
@@ -107,6 +110,7 @@ def _turn_context() -> TurnContext:
         conversation_id=1,
         turn_id=1,
         plan_editor=_FakePlanEditor(),
+        submission_id=submission_id,
     )
 
 
@@ -119,11 +123,88 @@ def _echo_task(task_id: str, message: str) -> TaskSpec:
     )
 
 
+def test_submission_fingerprint_tracks_execution_semantics_only() -> None:
+    original = _echo_task("task-1", "hello")
+    original.display = TaskDisplay(plan_title="First title")
+    original.metadata["general_planner"] = {"rationale": "first wording"}
+    cosmetic_change = original.model_copy(deep=True)
+    cosmetic_change.display.plan_title = "Different title"
+    cosmetic_change.metadata["general_planner"] = {"rationale": "different wording"}
+    execution_change = original.model_copy(deep=True)
+    execution_change.args["message"] = "different payload"
+
+    original_batch = PreparedTaskBatch(batch=TaskBatchInput(tasks=(original,)))
+    cosmetic_batch = PreparedTaskBatch(batch=TaskBatchInput(tasks=(cosmetic_change,)))
+    execution_batch = PreparedTaskBatch(batch=TaskBatchInput(tasks=(execution_change,)))
+
+    assert _prepared_submission_fingerprint(original_batch, "adapter:general") == _prepared_submission_fingerprint(
+        cosmetic_batch,
+        "adapter:general",
+    )
+    assert _prepared_submission_fingerprint(original_batch, "adapter:general") != _prepared_submission_fingerprint(
+        execution_batch,
+        "adapter:general",
+    )
+    assert _prepared_submission_fingerprint(original_batch, "adapter:general") != _prepared_submission_fingerprint(
+        original_batch,
+        "adapter:workbook",
+    )
+
+
 def _tool_executor(tmp_path: Path) -> ToolExecutor:
     return ToolExecutor(
         artifact_store=FileArtifactStore(tmp_path / "artifacts"),
         sandbox_backend=LocalBackend(),
     )
+
+
+class _CountingExecutor:
+    def __init__(self, inner: Executor) -> None:
+        self.inner = inner
+        self.run_count = 0
+
+    async def run(self, run, store):
+        self.run_count += 1
+        return await self.inner.run(run, store)
+
+
+class _MissNextBatchLookupStore(FileRunStore):
+    miss_next_batch_lookup = False
+
+    def __init__(self, root: Path) -> None:
+        super().__init__(root)
+        self.update_batch_count = 0
+
+    async def get_batch(self, batch_id: str):
+        if self.miss_next_batch_lookup:
+            self.miss_next_batch_lookup = False
+            raise FileNotFoundError(f"simulated stale read for {batch_id}")
+        return await super().get_batch(batch_id)
+
+    async def update_batch(self, batch):
+        self.update_batch_count += 1
+        await super().update_batch(batch)
+
+
+class _FailingDetailStore(FileRunStore):
+    fail_run_id = ""
+    detail_failures_remaining = 0
+
+    def __init__(self, root: Path) -> None:
+        super().__init__(root)
+        self.detail_calls = 0
+        self.list_batch_runs_calls = 0
+
+    async def get_task_detail(self, run_id: str, view: str):
+        self.detail_calls += 1
+        if run_id == self.fail_run_id and self.detail_failures_remaining > 0:
+            self.detail_failures_remaining -= 1
+            raise ConnectionError("transient detail read failure")
+        return await super().get_task_detail(run_id, view)
+
+    async def list_batch_runs(self, batch_id: str):
+        self.list_batch_runs_calls += 1
+        return await super().list_batch_runs(batch_id)
 
 
 @pytest.mark.asyncio
@@ -160,6 +241,7 @@ async def test_submit_prepared_preserves_caller_supplied_batch_metadata(tmp_path
     assert batch is not None
     assert batch.metadata["source"] == "request-builder"
     assert batch.metadata["trace_id"] == "abc-123"
+    assert batch.metadata["_task_runtime"]["submission_id"] == "submission-1"
 
 
 @pytest.mark.asyncio
@@ -176,3 +258,136 @@ async def test_submit_prepared_uses_caller_join_strategy(tmp_path: Path) -> None
     result = await manager.submit_prepared(_turn_context(), prepared)
 
     assert result.completed_count == 1
+
+
+@pytest.mark.asyncio
+async def test_submit_prepared_reuses_replay_but_executes_new_submission(tmp_path: Path) -> None:
+    executor = _CountingExecutor(_tool_executor(tmp_path))
+    store = _MissNextBatchLookupStore(tmp_path / "turn" / "results")
+    manager = TaskManager(store, executor, max_concurrency=1)
+    prepared = PreparedTaskBatch(
+        batch=TaskBatchInput(
+            tasks=(_echo_task("task-1", "again"),),
+            description="Replay-safe batch.",
+        ),
+    )
+    rerun_prepared = PreparedTaskBatch(
+        batch=TaskBatchInput(
+            tasks=(_echo_task("task-1", "changed for intentional rerun"),),
+            description="Intentional rerun batch.",
+        ),
+    )
+
+    replay_context = _turn_context("submission-1")
+    first = await manager.submit_prepared(replay_context, prepared)
+    updates_after_first = store.update_batch_count
+    store.miss_next_batch_lookup = True
+    replay = await manager.submit_prepared(replay_context, prepared)
+    rerun = await manager.submit_prepared(_turn_context("submission-2"), rerun_prepared)
+
+    assert replay.batch_id == first.batch_id
+    assert rerun.batch_id != first.batch_id
+    assert executor.run_count == 2
+    assert store.update_batch_count == updates_after_first + 1
+
+
+@pytest.mark.asyncio
+async def test_submit_prepared_rejects_divergent_replay(tmp_path: Path) -> None:
+    executor = _CountingExecutor(_tool_executor(tmp_path))
+    manager = TaskManager(FileRunStore(tmp_path / "turn" / "results"), executor, max_concurrency=1)
+    original = PreparedTaskBatch(
+        batch=TaskBatchInput(tasks=(_echo_task("task-1", "original"),), description="Original batch."),
+    )
+    divergent = PreparedTaskBatch(
+        batch=TaskBatchInput(tasks=(_echo_task("task-1", "different"),), description="Divergent replay."),
+    )
+
+    await manager.submit_prepared(_turn_context("submission-1"), original)
+
+    with pytest.raises(RuntimeError, match="diverged"):
+        await manager.submit_prepared(_turn_context("submission-1"), divergent)
+    assert executor.run_count == 1
+
+
+@pytest.mark.asyncio
+async def test_submit_prepared_rejects_incomplete_replay_batch(tmp_path: Path) -> None:
+    store = FileRunStore(tmp_path / "turn" / "results")
+    manager = TaskManager(store, _tool_executor(tmp_path), max_concurrency=2)
+    prepared = PreparedTaskBatch(
+        batch=TaskBatchInput(
+            tasks=(_echo_task("task-1", "one"), _echo_task("task-2", "two")),
+            description="Two-task batch.",
+        ),
+    )
+    context = _turn_context("submission-1")
+
+    first = await manager.submit_prepared(context, prepared)
+    runs = await store.list_batch_runs(first.batch_id)
+    shutil.rmtree(store.run_dir(first.batch_id, runs[-1].run_id))
+
+    with pytest.raises(RuntimeError, match="expected 2 materialized runs, found 1"):
+        await manager.submit_prepared(context, prepared)
+
+
+@pytest.mark.asyncio
+async def test_submit_prepared_replay_skips_execution_planning(tmp_path: Path, monkeypatch) -> None:
+    manager = TaskManager(FileRunStore(tmp_path / "turn" / "results"), _tool_executor(tmp_path), max_concurrency=1)
+    prepared = PreparedTaskBatch(
+        batch=TaskBatchInput(tasks=(_echo_task("task-1", "hello"),), description="Replay batch."),
+    )
+    context = _turn_context("submission-1")
+    first = await manager.submit_prepared(context, prepared)
+
+    async def unexpected_planning(*args, **kwargs):
+        raise AssertionError("execution planning must be skipped for replay")
+
+    monkeypatch.setattr(manager.submitter, "_plan_batch_execution", unexpected_planning)
+    replay = await manager.submit_prepared(context, prepared)
+
+    assert replay.batch_id == first.batch_id
+
+
+@pytest.mark.asyncio
+async def test_submit_prepared_replay_retries_transient_observation_failures(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    import app.biz.task_runtime.submitter as submitter_module
+
+    monkeypatch.setattr(submitter_module, "_REPLAY_RESULT_POLL_SECONDS", 0)
+    store = _FailingDetailStore(tmp_path / "turn" / "results")
+    manager = TaskManager(store, _tool_executor(tmp_path), max_concurrency=2)
+    prepared = PreparedTaskBatch(
+        batch=TaskBatchInput(
+            tasks=(_echo_task("task-1", "one"), _echo_task("task-2", "two")),
+            description="Two-task replay batch.",
+        ),
+    )
+    context = _turn_context("submission-1")
+    first = await manager.submit_prepared(context, prepared)
+    runs = await store.list_batch_runs(first.batch_id)
+    store.fail_run_id = runs[0].run_id
+    store.detail_failures_remaining = 1
+    store.detail_calls = 0
+    store.list_batch_runs_calls = 0
+
+    replay = await manager.submit_prepared(context, prepared)
+
+    assert replay.completed_count == 2
+    assert replay.failed_count == 0
+    assert store.detail_calls == 3
+    assert store.list_batch_runs_calls <= 4
+
+
+@pytest.mark.asyncio
+async def test_replayed_batch_result_wait_rejects_empty_runs(tmp_path: Path) -> None:
+    manager = TaskManager(FileRunStore(tmp_path / "turn" / "results"), _tool_executor(tmp_path), max_concurrency=1)
+    context = _turn_context("submission-1")
+    prepared = PreparedTaskBatch(
+        batch=TaskBatchInput(tasks=(_echo_task("task-1", "hello"),), description="Replay batch."),
+    )
+    result = await manager.submit_prepared(context, prepared)
+    batch = await manager.store.get_batch(result.batch_id)
+
+    with pytest.raises(RuntimeError, match="has no materialized runs"):
+        await manager.submitter._wait_for_replayed_batch_results(context, batch, [])

--- a/core/tests/task_runtime/test_submit_prepared_e2e.py
+++ b/core/tests/task_runtime/test_submit_prepared_e2e.py
@@ -165,6 +165,7 @@ def _turn_context() -> TurnContext:
         conversation_id=1,
         turn_id=1,
         plan_editor=_FakePlanEditor(),
+        submission_id="submission-1",
     )
 
 

--- a/core/tests/task_runtime/test_turn_context.py
+++ b/core/tests/task_runtime/test_turn_context.py
@@ -47,6 +47,7 @@ def _make_tool_context(*, agent_instance_id: int | None = 7) -> ToolContext:
         conversation_id=200,
         response_queue=asyncio.Queue(),
         plan_editor=_FakePlanEditor(),
+        submission_id="request-1",
     )
 
 
@@ -61,6 +62,18 @@ def test_from_tool_context_copies_identity_fields() -> None:
     assert ctx.conversation_id == 200
     assert ctx.turn_id == 42
     assert ctx.plan_editor is tc.plan_editor
+    assert ctx.submission_id == "request-1"
+
+
+def test_from_tool_context_accepts_delegate_submission_scope() -> None:
+    ctx = TurnContext.from_tool_context(
+        _make_tool_context(),
+        submission_id="request-1:delegate",
+        submission_source="adapter:workbook",
+    )
+
+    assert ctx.submission_id == "request-1:delegate"
+    assert ctx.submission_source == "adapter:workbook"
 
 
 def test_from_tool_context_coerces_none_agent_instance_id_to_zero() -> None:

--- a/proto/conversation/api.proto
+++ b/proto/conversation/api.proto
@@ -46,6 +46,7 @@ message ChatRequest {
   string agent_role = 15;          // @gotag: json:"agentRole,omitempty"
   string project_name = 16;         // @gotag: json:"projectName,omitempty"
   bool need_update_title = 17;      // @gotag: json:"needUpdateTitle,omitempty"
+  string submission_id = 18;        // @gotag: json:"submissionId,omitempty"
 }
 
 message ChatDirectResponse {


### PR DESCRIPTION
Syncs the upstream taskruntime stream-replay fix into this repo.

## Summary

- give every chat request a stable `submission_id` (proto `ChatRequest.submission_id`, set by the backend) and derive per-delegate submission identities from it
- derive deterministic batch IDs and task idempotency keys from the submission id, so a backend→core transport replay reuses the existing batch instead of re-executing it
- validate a submission fingerprint before reusing a replayed batch, and observe (never re-own) the original batch's runs
- suppress whole-generation chat retries once a task batch has been submitted, reporting that the submitted tasks keep running
- recognize GORM-translated duplicate-key errors in the task-runtime DAL
- replace `TASK_RUNTIME_RECONCILE_INTERVAL_SECONDS` with `TASK_RUNTIME_REPLAY_MATERIALIZATION_TIMEOUT_SECONDS`, and run a bounded startup recovery (immediate + one delayed pass) driven by the shutdown event

## Validation

- `./scripts/lint.sh --backend` / `--core`
- `cd backend && go build ./... && go test ./...`
- `cd core && uv run pytest` (823 passed)

## Rollout

Pause new task submissions and let active taskruntime batches drain before rolling mixed backend/core versions: the old and new batch identity formats cannot safely coexist.