### PR TITLE
Add hyperlink to GELab-Zero-4B release note

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@
 | Date | Type | Update |
 |------|------|--------|
 | **20260722** | Release | Released **Sico v0.3.0**, introducing multi-session chat, project context management and experience improvements. |
-| **20260708** | Model | Released **GELab-Zero-4B-preview-Sico-Evolution**, an open-source GUI foundation model on Hugging Face. |
+| **20260708** | Model | Released [**GELab-Zero-4B-preview-Sico-Evolution**](https://huggingface.co/microsoft/GELab-Zero-4B-preview-Sico-Evolution), an open-source GUI foundation model on HuggingFace. |
 
 ## What is Sico?
 


### PR DESCRIPTION
## Summary
Updated the release note for GELab-Zero-4B-preview-Sico-Evolution to include a hyperlink.
