### PR TITLE
Fix LocalBackend environment isolation for skill execution

### DIFF
--- a/core/app/biz/task_runtime/executors/command_backend.py
+++ b/core/app/biz/task_runtime/executors/command_backend.py
@@ -343,7 +343,7 @@ class LocalBackend:
 
     async def run(self, spec: CommandSpec) -> CommandResult:
         cwd = spec.cwd or _first_mount_host_path(spec) or os.getcwd()
-        env = {**os.environ, **spec.env}
+        env = _local_subprocess_env(spec.env)
         proc = await asyncio.create_subprocess_exec(
             *spec.argv,
             cwd=cwd,
@@ -355,6 +355,28 @@ class LocalBackend:
 
     def open_session(self, *, pod_name: str = "", image: str = "") -> CommandSession:
         return _StatelessSession(self)
+
+
+def _local_subprocess_env(overrides: dict[str, str]) -> dict[str, str]:
+    env = dict(os.environ)
+    inherited_venv_roots = {
+        value
+        for name in ("VIRTUAL_ENV", "UV_PROJECT_ENVIRONMENT")
+        if (value := env.pop(name, ""))
+    }
+    if path := env.get("PATH"):
+        inherited_executable_dirs = {
+            os.path.normcase(os.path.realpath(os.path.join(root, directory)))
+            for root in inherited_venv_roots
+            for directory in ("bin", "Scripts")
+        }
+        env["PATH"] = os.pathsep.join(
+            entry
+            for entry in path.split(os.pathsep)
+            if os.path.normcase(os.path.realpath(entry)) not in inherited_executable_dirs
+        )
+    env.update(overrides)
+    return env
 
 
 def _first_mount_host_path(spec: CommandSpec) -> str:

--- a/core/tests/task_runtime/test_command_backend.py
+++ b/core/tests/task_runtime/test_command_backend.py
@@ -18,6 +18,7 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
+import json
 import os
 import sys
 
@@ -143,6 +144,28 @@ async def test_local_backend_merges_env(tmp_path):
     )
     result = await LocalBackend().run(spec)
     assert result.stdout.strip() == "from-spec"
+
+
+@pytest.mark.asyncio
+async def test_local_backend_does_not_inherit_host_python_environment(monkeypatch, tmp_path):
+    host_venv = tmp_path / "core-venv"
+    host_venv_bin = host_venv / ("Scripts" if sys.platform == "win32" else "bin")
+    safe_bin = tmp_path / "system-bin"
+    monkeypatch.setenv("VIRTUAL_ENV", str(host_venv))
+    monkeypatch.setenv("UV_PROJECT_ENVIRONMENT", str(host_venv))
+    monkeypatch.setenv("PATH", os.pathsep.join((str(host_venv_bin), str(safe_bin))))
+    script = (
+        "import json, os; "
+        "print(json.dumps({key: os.environ.get(key) for key in "
+        "('VIRTUAL_ENV', 'UV_PROJECT_ENVIRONMENT', 'PATH')}))"
+    )
+
+    result = await LocalBackend().run(CommandSpec(argv=[sys.executable, "-c", script], cwd=str(tmp_path)))
+
+    child_env = json.loads(result.stdout)
+    assert child_env["VIRTUAL_ENV"] is None
+    assert child_env["UV_PROJECT_ENVIRONMENT"] is None
+    assert child_env["PATH"].split(os.pathsep) == [str(safe_bin)]
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Problem

LocalBackend inherited VIRTUAL_ENV and UV_PROJECT_ENVIRONMENT
from the core process when executing skills.

As a result, android-tester's `uv sync` could synchronize its
dependencies into core's /opt/venv and remove core dependencies,
causing lazy imports such as `toon` to fail.

## Fix

Remove VIRTUAL_ENV and UV_PROJECT_ENVIRONMENT from the environment
passed to LocalBackend skill subprocesses.

## Validation

- 39/39 command backend tests passed
- android-tester execution completed successfully
- EPE learning completed successfully
- Core venv contains 211 packages after rebuild
- `from toon import encode` succeeds
- `import grpc, azure, toon` succeeds